### PR TITLE
feat(mobile): implement projects CRUD with mock data

### DIFF
--- a/apps/mobile/src/app/projects/[id].tsx
+++ b/apps/mobile/src/app/projects/[id].tsx
@@ -1,0 +1,213 @@
+import { useState, useEffect } from "react";
+import { View, Text, TextInput, Switch, Pressable, ActivityIndicator } from "react-native";
+import { useRouter, useLocalSearchParams } from "expo-router";
+import { useProjectStore } from "../../stores/project.store";
+import { useI18n } from "../../hooks/useI18n";
+import { Project, Language } from "@repo/shared";
+import { Button } from "../../components/Button";
+import { ConfirmModal } from "../../components/ConfirmModal";
+
+interface ProjectFormData extends Omit<Project, "id"> {}
+
+const initialFormData: ProjectFormData = {
+  name: "",
+  default_language: "es" as Language,
+  supported_languages: ["es", "en"] as Language[],
+  cascade_timeout_minutes: 30,
+  max_cascade_attempts: 10,
+  is_active: true,
+};
+
+export default function ProjectFormScreen() {
+  const router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const isEditMode = id !== "new";
+
+  const {
+    selectedProject,
+    selectProject,
+    createProject,
+    updateProject,
+    deleteProject,
+    isLoading,
+    isSaving,
+  } = useProjectStore();
+  const { t } = useI18n();
+
+  const [formData, setFormData] = useState<ProjectFormData>(initialFormData);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  useEffect(() => {
+    if (isEditMode && id) {
+      selectProject(parseInt(id));
+    }
+  }, [isEditMode, id, selectProject]);
+
+  useEffect(() => {
+    if (isEditMode && selectedProject) {
+      setFormData({
+        name: selectedProject.name,
+        default_language: selectedProject.default_language,
+        supported_languages: [...selectedProject.supported_languages],
+        cascade_timeout_minutes: selectedProject.cascade_timeout_minutes,
+        max_cascade_attempts: selectedProject.max_cascade_attempts,
+        is_active: selectedProject.is_active,
+      });
+    }
+  }, [isEditMode, selectedProject]);
+
+  const handleSave = async () => {
+    if (!formData.name.trim()) {
+      return;
+    }
+
+    if (isEditMode && id) {
+      const result = await updateProject(parseInt(id), formData);
+      if (result) {
+        router.push("/projects");
+      }
+    } else {
+      const result = await createProject(formData);
+      if (result) {
+        router.push("/projects");
+      }
+    }
+  };
+
+  const handleDelete = () => {
+    setShowDeleteModal(true);
+  };
+
+  const confirmDelete = () => {
+    deleteProject(parseInt(id!)).then((success) => {
+      if (success) router.push("/projects");
+    });
+    setShowDeleteModal(false);
+  };
+
+  const toggleLanguage = (lang: Language) => {
+    const current = formData.supported_languages;
+    const newLanguages = current.includes(lang)
+      ? current.filter((l) => l !== lang)
+      : [...current, lang];
+    setFormData({ ...formData, supported_languages: newLanguages });
+  };
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 bg-gray-50 p-5 pt-20 items-center justify-center">
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1 bg-gray-50 p-5 pt-20">
+      <View className="flex-1 max-w-md w-full mx-auto">
+        <View className="mb-5">
+          <Text className="text-2xl font-bold text-gray-900 text-center">
+            {isEditMode ? t("edit_project") : t("create_project")}
+          </Text>
+        </View>
+
+        <View className="mb-5">
+          <Text className="text-sm font-medium text-gray-700 mb-2">{t("project_name")}</Text>
+          <TextInput
+            className="bg-white border border-gray-300 p-3 rounded-lg"
+            value={formData.name}
+            onChangeText={(text) => setFormData({ ...formData, name: text })}
+            placeholder={t("project_name")}
+          />
+        </View>
+
+        <View className="mb-5 flex-row gap-4">
+          <View className="flex-1">
+            <Text className="text-sm font-medium text-gray-700 mb-2">{t("max_attempts")}</Text>
+            <TextInput
+              className="bg-white border border-gray-300 p-3 rounded-lg"
+              value={formData.max_cascade_attempts.toString()}
+              onChangeText={(text) =>
+                setFormData({ ...formData, max_cascade_attempts: parseInt(text) || 0 })
+              }
+              keyboardType="numeric"
+            />
+          </View>
+          <View className="flex-1">
+            <Text className="text-sm font-medium text-gray-700 mb-2">{t("cascade_timeout")}</Text>
+            <TextInput
+              className="bg-white border border-gray-300 p-3 rounded-lg"
+              value={formData.cascade_timeout_minutes.toString()}
+              onChangeText={(text) =>
+                setFormData({ ...formData, cascade_timeout_minutes: parseInt(text) || 0 })
+              }
+              keyboardType="numeric"
+            />
+          </View>
+        </View>
+
+        <View className="mb-5">
+          <Text className="text-sm font-medium text-gray-700 mb-2">{t("supported_languages")}</Text>
+          <View className="flex-row gap-4 items-center">
+            <View className="flex-row gap-2">
+              {(["es", "en"] as Language[]).map((lang) => (
+                <Pressable
+                  key={lang}
+                  className={`px-4 py-2 rounded-lg border ${
+                    formData.supported_languages.includes(lang)
+                      ? "bg-green-600 border-green-600"
+                      : "bg-white border-gray-300"
+                  }`}
+                  onPress={() => toggleLanguage(lang)}
+                >
+                  <Text
+                    className={
+                      formData.supported_languages.includes(lang) ? "text-white" : "text-gray-700"
+                    }
+                  >
+                    {lang.toUpperCase()}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+            <View className="flex-row items-center gap-2 ml-auto">
+              <Text className="text-sm text-gray-700">{t("active")}</Text>
+              <Switch
+                value={formData.is_active}
+                onValueChange={(value) => setFormData({ ...formData, is_active: value })}
+              />
+            </View>
+          </View>
+        </View>
+
+        <View className="mt-6 gap-3">
+          <Button
+            title={isSaving ? t("saving") : t("save")}
+            variant="primary"
+            disabled={isSaving}
+            onPress={handleSave}
+          />
+
+          <Button
+            title={t("cancel")}
+            variant="secondary"
+            onPress={() => router.push("/projects")}
+          />
+
+          {isEditMode && <Button title={t("delete")} variant="danger" onPress={handleDelete} />}
+        </View>
+      </View>
+
+      <ConfirmModal
+        visible={showDeleteModal}
+        title={t("confirm_delete")}
+        message={`${t("delete_confirm_message")} "${selectedProject?.name}"?`}
+        confirmText={t("delete")}
+        cancelText={t("cancel")}
+        onConfirm={confirmDelete}
+        onCancel={() => setShowDeleteModal(false)}
+        variant="danger"
+        isLoading={isSaving}
+      />
+    </View>
+  );
+}

--- a/apps/mobile/src/app/projects/index.tsx
+++ b/apps/mobile/src/app/projects/index.tsx
@@ -1,108 +1,107 @@
-import { useEffect } from "react";
+import { useCallback } from "react";
+import { useFocusEffect, useRouter, Link } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { Text, View, ActivityIndicator, FlatList, StyleSheet } from "react-native";
+import { Text, View, ActivityIndicator } from "react-native";
 import { useProjectStore } from "../../stores/project.store";
 import { useI18n } from "../../hooks/useI18n";
+import { Project } from "@repo/shared";
+import { Button } from "../../components/Button";
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#f9f9f9",
-    alignItems: "center",
-    justifyContent: "center",
-    paddingTop: 80,
-    paddingHorizontal: 20,
-  },
-  title: {
-    fontSize: 28,
-    fontWeight: "bold",
-    color: "#1a1a1a",
-  },
-  subtitle: {
-    fontSize: 14,
-    color: "#666",
-    marginBottom: 20,
-    fontStyle: "italic",
-  },
-  error: {
-    color: "red",
-    marginTop: 20,
-  },
-  list: {
-    width: "100%",
-  },
-  card: {
-    backgroundColor: "#fff",
-    padding: 20,
-    borderRadius: 12,
-    marginBottom: 12,
-    borderWidth: 1,
-    borderColor: "#eee",
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 4,
-    elevation: 2,
-  },
-  projectName: {
-    fontSize: 18,
-    fontWeight: "600",
-    marginBottom: 4,
-  },
-  projectLang: {
-    fontSize: 14,
-    color: "#555",
-  },
-  projectStatus: {
-    fontSize: 14,
-    fontWeight: "500",
-    marginTop: 6,
-  },
-  loading: {
-    marginTop: 20,
-  },
-});
+interface ProjectCardProps {
+  project: Project;
+}
+
+function ProjectCard({ project }: ProjectCardProps) {
+  const { t } = useI18n();
+
+  return (
+    <Link href={`/projects/${project.id}`} className="block mb-3 w-full">
+      <View className="bg-white p-4 rounded-xl border border-gray-200 shadow-sm w-full">
+        <Text className="text-lg font-bold text-gray-900 mb-2 text-center">{project.name}</Text>
+
+        <View className="flex-row gap-2 mb-2 justify-center">
+          <View className="bg-blue-100 px-2 py-1 rounded">
+            <Text className="text-xs text-blue-700">
+              {t("default_language")}: {project.default_language.toUpperCase()}
+            </Text>
+          </View>
+          <View
+            className={`px-2 py-1 rounded ${project.is_active ? "bg-green-100" : "bg-gray-100"}`}
+          >
+            <Text className={`text-xs ${project.is_active ? "text-green-700" : "text-gray-500"}`}>
+              {project.is_active ? "🟢 " + t("active") : "🔴 " + t("inactive")}
+            </Text>
+          </View>
+        </View>
+
+        <View className="border-t border-gray-100 pt-2 mt-2">
+          <Text className="text-xs text-gray-500 mb-1">
+            {t("supported_languages")}:{" "}
+            {project.supported_languages.map((l) => l.toUpperCase()).join(", ")}
+          </Text>
+          <View className="flex-row gap-4">
+            <Text className="text-xs text-gray-500">
+              ⏱️ {t("cascade_timeout")}: {project.cascade_timeout_minutes} min
+            </Text>
+            <Text className="text-xs text-gray-500">
+              🔄 {t("max_attempts")}: {project.max_cascade_attempts}
+            </Text>
+          </View>
+        </View>
+      </View>
+    </Link>
+  );
+}
 
 export default function ProjectsScreen() {
+  const router = useRouter();
   const { projects, isLoading, error, fetchProjects } = useProjectStore();
   const { t } = useI18n();
 
-  useEffect(() => {
-    fetchProjects();
-  }, [fetchProjects]);
+  useFocusEffect(
+    useCallback(() => {
+      fetchProjects();
+    }, [fetchProjects]),
+  );
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>{t("app_title")}</Text>
-      <Text style={styles.subtitle}>{t("mock_mode")}</Text>
+    <View className="flex-1 bg-gray-50 pt-20 px-5">
+      <View className="flex-1 max-w-md w-full mx-auto">
+        <View className="mb-5">
+          <Text className="text-3xl font-bold text-gray-900 text-center">{t("app_title")}</Text>
+          <Text className="text-sm text-gray-500 italic text-center mt-1">{t("mock_mode")}</Text>
+        </View>
 
-      {isLoading && <ActivityIndicator size="large" color="#0000ff" style={styles.loading} />}
+        {isLoading && (
+          <View className="mb-5">
+            <ActivityIndicator size="large" />
+          </View>
+        )}
 
-      {error && (
-        <Text style={styles.error}>
-          {t("error")}: {error}
-        </Text>
-      )}
+        {error && (
+          <View className="bg-red-100 p-4 rounded-lg mb-5">
+            <Text className="text-red-700">
+              {t("error")}: {error}
+            </Text>
+          </View>
+        )}
 
-      {!isLoading && !error && (
-        <FlatList
-          data={projects}
-          keyExtractor={(item) => item.id.toString()}
-          style={styles.list}
-          renderItem={({ item }) => (
-            <View style={styles.card}>
-              <Text style={styles.projectName}>{item.name}</Text>
-              <Text style={styles.projectLang}>
-                {t("default_language")}: {item.default_language.toUpperCase()}
-              </Text>
-              <Text style={styles.projectStatus}>
-                {item.is_active ? `🟢 ${t("active")}` : `🔴 ${t("inactive")}`}
-              </Text>
-            </View>
-          )}
-          ListEmptyComponent={<Text>{t("no_projects")}</Text>}
-        />
-      )}
+        {!isLoading && !error && projects.length > 0 && (
+          <View className="w-full items-center mb-5">
+            {projects.map((project) => (
+              <ProjectCard key={project.id} project={project} />
+            ))}
+          </View>
+        )}
+
+        {!isLoading && !error && projects.length === 0 && (
+          <Text className="text-gray-500 text-center mb-5">{t("no_projects")}</Text>
+        )}
+
+        <View className="w-full">
+          <Button title={t("add_project")} icon="+" onPress={() => router.push("/projects/new")} />
+        </View>
+      </View>
 
       <StatusBar style="auto" />
     </View>

--- a/apps/mobile/src/components/Button.tsx
+++ b/apps/mobile/src/components/Button.tsx
@@ -1,0 +1,48 @@
+import { Pressable, Text, ActivityIndicator, ViewStyle, TextStyle } from "react-native";
+
+type ButtonVariant = "primary" | "secondary" | "danger";
+
+interface ButtonProps {
+  title: string;
+  variant?: ButtonVariant;
+  onPress: () => void;
+  disabled?: boolean;
+  icon?: string;
+}
+
+const variantStyles: Record<ButtonVariant, { container: string; text: string }> = {
+  primary: {
+    container: "bg-green-600",
+    text: "text-white",
+  },
+  secondary: {
+    container: "bg-white border border-gray-300",
+    text: "text-gray-700",
+  },
+  danger: {
+    container: "bg-red-600",
+    text: "text-white",
+  },
+};
+
+export function Button({
+  title,
+  variant = "primary",
+  onPress,
+  disabled = false,
+  icon,
+}: ButtonProps) {
+  const styles = variantStyles[variant];
+  const isDisabled = disabled;
+
+  return (
+    <Pressable
+      className={`py-3 px-4 rounded-lg items-center justify-center flex-row gap-2 ${styles.container} ${isDisabled ? "opacity-50" : ""}`}
+      onPress={onPress}
+      disabled={isDisabled}
+    >
+      {icon && <Text className="text-lg">{icon}</Text>}
+      <Text className={`font-semibold text-center ${styles.text}`}>{title}</Text>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/components/ConfirmModal.tsx
+++ b/apps/mobile/src/components/ConfirmModal.tsx
@@ -1,0 +1,52 @@
+import { Text, View, Modal, Pressable } from "react-native";
+import { Button } from "./Button";
+
+interface ConfirmModalProps {
+  visible: boolean;
+  title: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  variant?: "danger" | "primary";
+  isLoading?: boolean;
+}
+
+export function ConfirmModal({
+  visible,
+  title,
+  message,
+  confirmText = "Confirm",
+  cancelText = "Cancel",
+  onConfirm,
+  onCancel,
+  variant = "danger",
+  isLoading = false,
+}: ConfirmModalProps) {
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onCancel}>
+      <Pressable className="flex-1 bg-black/50 items-center justify-center" onPress={onCancel}>
+        <Pressable className="bg-white rounded-2xl p-6 w-80 shadow-xl" onPress={() => {}}>
+          <Text className="text-xl font-bold text-gray-900 mb-2">{title}</Text>
+          <Text className="text-gray-600 mb-6">{message}</Text>
+
+          <View className="gap-3">
+            <Button
+              title={confirmText}
+              variant={variant}
+              onPress={onConfirm}
+              disabled={isLoading}
+            />
+            <Button
+              title={cancelText}
+              variant="secondary"
+              onPress={onCancel}
+              disabled={isLoading}
+            />
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/config/env.ts
+++ b/apps/mobile/src/config/env.ts
@@ -1,0 +1,15 @@
+// Environment configuration
+// Change these values depending on the environment:
+// - Mock: for frontend development without real backend
+// - Prod: for connecting to the real backend
+
+export const ENV = {
+  // Set to 'false' to use the real backend
+  USE_MOCKS: true,
+
+  // Backend URL (only used when USE_MOCKS = false)
+  API_URL: "http://localhost:3000",
+} as const;
+
+// Development mode check
+export const isDev = process.env.NODE_ENV !== "production";

--- a/apps/mobile/src/config/local.example.ts
+++ b/apps/mobile/src/config/local.example.ts
@@ -1,0 +1,16 @@
+/**
+ * Local environment configuration example
+ * Copy this file to `local.ts` and fill in your values
+ * DO NOT commit local.ts to version control
+ */
+
+// Copy this file to `local.ts` and configure:
+// cp local.example.ts local.ts
+
+export const local = {
+  // Set to "true" to use mock services instead of real APIs
+  USE_MOCKS: true,
+
+  // Your API URL when not using mocks
+  // API_URL: "https://api.example.com",
+};

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -2,9 +2,22 @@
   "app_title": "Impenetrable Connect",
   "mock_mode": "[Frontend-First Mock Mode]",
   "loading": "Loading...",
+  "saving": "Saving...",
   "error": "Error",
   "no_projects": "No projects found",
   "default_language": "Default Language",
+  "supported_languages": "Supported Languages",
+  "cascade_timeout": "Timeout (min)",
+  "max_attempts": "Max Attempts",
   "active": "Active",
-  "inactive": "Inactive"
+  "inactive": "Inactive",
+  "add_project": "Add Project",
+  "create_project": "Create Project",
+  "edit_project": "Edit Project",
+  "project_name": "Project Name",
+  "save": "Save",
+  "cancel": "Cancel",
+  "delete": "Delete",
+  "confirm_delete": "Confirm Delete",
+  "delete_confirm_message": "Are you sure you want to delete"
 }

--- a/apps/mobile/src/i18n/locales/es.json
+++ b/apps/mobile/src/i18n/locales/es.json
@@ -2,9 +2,22 @@
   "app_title": "Impenetrable Connect",
   "mock_mode": "[Modo Mock Frontend-First]",
   "loading": "Cargando...",
+  "saving": "Guardando...",
   "error": "Error",
   "no_projects": "No se encontraron proyectos",
   "default_language": "Idioma predeterminado",
+  "supported_languages": "Idiomas soportados",
+  "cascade_timeout": "Timeout (min)",
+  "max_attempts": "Intentos máximos",
   "active": "Activo",
-  "inactive": "Inactivo"
+  "inactive": "Inactivo",
+  "add_project": "Agregar Proyecto",
+  "create_project": "Crear Proyecto",
+  "edit_project": "Editar Proyecto",
+  "project_name": "Nombre del Proyecto",
+  "save": "Guardar",
+  "cancel": "Cancelar",
+  "delete": "Eliminar",
+  "confirm_delete": "Confirmar Eliminación",
+  "delete_confirm_message": "¿Estás seguro de que deseas eliminar"
 }

--- a/apps/mobile/src/services/project.service.ts
+++ b/apps/mobile/src/services/project.service.ts
@@ -1,5 +1,6 @@
 import { Project } from "@repo/shared";
 import { MOCK_PROJECTS } from "../mocks/projects";
+import { logger } from "./logger.service";
 
 // EXPO_PUBLIC_ prefix makes vars available in the JS bundle at runtime
 const USE_MOCKS = process.env.EXPO_PUBLIC_USE_MOCKS === "true";
@@ -12,25 +13,60 @@ const API_URL = process.env.EXPO_PUBLIC_API_URL;
 interface ProjectServiceInterface {
   getProjects(): Promise<Project[]>;
   getProjectById(id: number): Promise<Project | null>;
-  saveProject(project: Partial<Project>): Promise<{ success: boolean }>;
+  createProject(project: Omit<Project, "id">): Promise<Project>;
+  updateProject(id: number, project: Partial<Project>): Promise<Project>;
+  deleteProject(id: number): Promise<boolean>;
 }
 
 /**
  * 🛠️ MOCK Implementation (Used during design/MVP phase)
  */
+let mockProjects = [...MOCK_PROJECTS];
+let nextId = 3;
+
 const MockProjectService: ProjectServiceInterface = {
   getProjects: async () => {
     await new Promise((r) => setTimeout(r, 800));
-    return MOCK_PROJECTS;
+    return [...mockProjects];
   },
-  getProjectById: async (id) => {
+
+  getProjectById: async (id: number) => {
     await new Promise((r) => setTimeout(r, 500));
-    return MOCK_PROJECTS.find((p) => p.id === id) || null;
+    return mockProjects.find((p) => p.id === id) || null;
   },
-  saveProject: async (project) => {
-    await new Promise((r) => setTimeout(r, 1200));
-    console.log("[MOCK API] Saving project:", project);
-    return { success: true };
+
+  createProject: async (project: Omit<Project, "id">) => {
+    await new Promise((r) => setTimeout(r, 800));
+    const newProject: Project = {
+      ...project,
+      id: nextId++,
+    };
+    mockProjects = [...mockProjects, newProject];
+    logger.info("[MOCK API] Created project:", newProject);
+    return newProject;
+  },
+
+  updateProject: async (id: number, project: Partial<Project>) => {
+    await new Promise((r) => setTimeout(r, 800));
+    const index = mockProjects.findIndex((p) => p.id === id);
+    if (index === -1) {
+      throw new Error("Project not found");
+    }
+    const updatedProject = { ...mockProjects[index], ...project };
+    mockProjects = mockProjects.map((p) => (p.id === id ? updatedProject : p));
+    logger.info("[MOCK API] Updated project:", updatedProject);
+    return updatedProject;
+  },
+
+  deleteProject: async (id: number) => {
+    await new Promise((r) => setTimeout(r, 800));
+    const exists = mockProjects.some((p) => p.id === id);
+    if (!exists) {
+      return false;
+    }
+    mockProjects = mockProjects.filter((p) => p.id !== id);
+    logger.info("[MOCK API] Deleted project with id:", id);
+    return true;
   },
 };
 
@@ -43,18 +79,38 @@ const RestProjectService: ProjectServiceInterface = {
     if (!response.ok) throw new Error("API error fetching projects");
     return response.json();
   },
-  getProjectById: async (id) => {
+
+  getProjectById: async (id: number) => {
     const response = await fetch(`${API_URL}/projects/${id}`);
     if (!response.ok) throw new Error("API error fetching project by ID");
     return response.json();
   },
-  saveProject: async (project) => {
+
+  createProject: async (project: Omit<Project, "id">) => {
     const response = await fetch(`${API_URL}/projects`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(project),
     });
-    return { success: response.ok };
+    if (!response.ok) throw new Error("API error creating project");
+    return response.json();
+  },
+
+  updateProject: async (id: number, project: Partial<Project>) => {
+    const response = await fetch(`${API_URL}/projects/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(project),
+    });
+    if (!response.ok) throw new Error("API error updating project");
+    return response.json();
+  },
+
+  deleteProject: async (id: number) => {
+    const response = await fetch(`${API_URL}/projects/${id}`, {
+      method: "DELETE",
+    });
+    return response.ok;
   },
 };
 

--- a/apps/mobile/src/stores/project.store.ts
+++ b/apps/mobile/src/stores/project.store.ts
@@ -7,21 +7,27 @@ interface ProjectState {
   projects: Project[];
   selectedProject: Project | null;
   isLoading: boolean;
+  isSaving: boolean;
   error: string | null;
 
   // Actions
   fetchProjects: () => Promise<void>;
   selectProject: (id: number) => Promise<void>;
+  createProject: (project: Omit<Project, "id">) => Promise<Project | null>;
+  updateProject: (id: number, project: Partial<Project>) => Promise<Project | null>;
+  deleteProject: (id: number) => Promise<boolean>;
 }
 
 /**
  * Project Store (Zustand)
  * The UI consumes this store, oblivious to whether the data comes from a mock or a real API.
+ * Uses isLoading for read operations and isSaving for mutations.
  */
-export const useProjectStore = create<ProjectState>((set) => ({
+export const useProjectStore = create<ProjectState>((set, get) => ({
   projects: [],
   selectedProject: null,
   isLoading: false,
+  isSaving: false,
   error: null,
 
   fetchProjects: async () => {
@@ -43,6 +49,55 @@ export const useProjectStore = create<ProjectState>((set) => ({
     } catch (err) {
       logger.error(`Error fetching project with ID: ${id}`, err);
       set({ error: "Project not found", isLoading: false });
+    }
+  },
+
+  createProject: async (project: Omit<Project, "id">) => {
+    set({ isSaving: true, error: null });
+    try {
+      const newProject = await ProjectService.createProject(project);
+      const currentProjects = get().projects;
+      set({ projects: [...currentProjects, newProject], isSaving: false });
+      return newProject;
+    } catch (err) {
+      logger.error("Error creating project", err);
+      set({ error: "Failed to create project", isSaving: false });
+      return null;
+    }
+  },
+
+  updateProject: async (id: number, project: Partial<Project>) => {
+    set({ isSaving: true, error: null });
+    try {
+      const updatedProject = await ProjectService.updateProject(id, project);
+      const currentProjects = get().projects;
+      const updatedList = currentProjects.map((p) => (p.id === id ? updatedProject : p));
+      set({ projects: updatedList, selectedProject: updatedProject, isSaving: false });
+      return updatedProject;
+    } catch (err) {
+      logger.error(`Error updating project with ID: ${id}`, err);
+      set({ error: "Failed to update project", isSaving: false });
+      return null;
+    }
+  },
+
+  deleteProject: async (id: number) => {
+    set({ isSaving: true, error: null });
+    try {
+      const success = await ProjectService.deleteProject(id);
+      if (success) {
+        const currentProjects = get().projects;
+        set({
+          projects: currentProjects.filter((p) => p.id !== id),
+          selectedProject: null,
+          isSaving: false,
+        });
+      }
+      return success;
+    } catch (err) {
+      logger.error(`Error deleting project with ID: ${id}`, err);
+      set({ error: "Failed to delete project", isSaving: false });
+      return false;
     }
   },
 }));


### PR DESCRIPTION
## Summary

Implements full CRUD operations for Projects in the mobile app with mock data support.

- Add ProjectService with CRUD methods (create, update, delete)
- Add Zustand store with isLoading (reads) and isSaving (mutations) states
- Add Button and ConfirmModal reusable components
- Add project list screen with cards
- Add project form screen (create/edit)
- Add i18n translations (es, en)

## Changes

| File | Change |
|------|--------|
| `apps/mobile/src/services/project.service.ts` | Added CRUD methods to service |
| `apps/mobile/src/stores/project.store.ts` | Added isLoading/isSaving states |
| `apps/mobile/src/components/Button.tsx` | New reusable button component |
| `apps/mobile/src/components/ConfirmModal.tsx` | New reusable modal component |
| `apps/mobile/src/app/projects/index.tsx` | Project list screen |
| `apps/mobile/src/app/projects/[id].tsx` | Project form screen |
| `apps/mobile/src/i18n/locales/en.json` | English translations |
| `apps/mobile/src/i18n/locales/es.json` | Spanish translations |

## Test Plan

- [x] Manual testing: create, edit, delete projects
- [x] i18n switching works correctly
- [x] GGA code review passes

## Checklist

- [x] Linked issue #20 (approved)
- [x] Added type:feature label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers