### PR TITLE
fix(mobile): add field validation and fix Android navigator context

### DIFF
--- a/apps/mobile/src/app/projects/[id].tsx
+++ b/apps/mobile/src/app/projects/[id].tsx
@@ -3,7 +3,7 @@ import { View, Text, TextInput, Switch, Pressable, ActivityIndicator } from "rea
 import { useRouter, useLocalSearchParams } from "expo-router";
 import { useProjectStore } from "../../stores/project.store";
 import { useI18n } from "../../hooks/useI18n";
-import { Project, Language } from "@repo/shared";
+import { Project, Language, PROJECT_CONSTRAINTS, CreateProjectSchema } from "@repo/shared";
 import { Button } from "../../components/Button";
 import { ConfirmModal } from "../../components/ConfirmModal";
 
@@ -36,6 +36,7 @@ export default function ProjectFormScreen() {
 
   const [formData, setFormData] = useState<ProjectFormData>(initialFormData);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
     if (isEditMode && id) {
@@ -56,8 +57,57 @@ export default function ProjectFormScreen() {
     }
   }, [isEditMode, selectedProject]);
 
+  const validateForm = (): boolean => {
+    const result = CreateProjectSchema.safeParse(formData);
+    if (!result.success) {
+      const errors: Record<string, string> = {};
+
+      for (const issue of result.error.issues) {
+        const fieldName = issue.path.join(".");
+        let message = issue.message;
+
+        // Map Zod errors to i18n keys
+        if (fieldName === "name") {
+          if (issue.code === "too_small") {
+            message = t("validation.name_min_length");
+          } else if (issue.code === "too_big") {
+            message = t("validation.name_max_length");
+          } else if (issue.code === "invalid_type") {
+            message = t("validation.name_required");
+          }
+        } else if (fieldName === "max_cascade_attempts") {
+          if (issue.code === "too_small") {
+            message = t("validation.max_attempts_min");
+          } else if (issue.code === "too_big") {
+            message = t("validation.max_attempts_max");
+          } else if (issue.code === "invalid_type") {
+            message = t("validation.max_attempts_required");
+          }
+        } else if (fieldName === "cascade_timeout_minutes") {
+          if (issue.code === "too_small") {
+            message = t("validation.timeout_min");
+          } else if (issue.code === "too_big") {
+            message = t("validation.timeout_max");
+          } else if (issue.code === "invalid_type") {
+            message = t("validation.timeout_required");
+          }
+        } else if (fieldName === "supported_languages") {
+          message = t("validation.supported_languages_required");
+        }
+
+        errors[fieldName] = message;
+      }
+
+      setFieldErrors(errors);
+      return false;
+    }
+    setFieldErrors({});
+    return true;
+  };
+
   const handleSave = async () => {
-    if (!formData.name.trim()) {
+    const isValid = validateForm();
+    if (!isValid) {
       return;
     }
 
@@ -78,11 +128,12 @@ export default function ProjectFormScreen() {
     setShowDeleteModal(true);
   };
 
-  const confirmDelete = () => {
-    deleteProject(parseInt(id!)).then((success) => {
-      if (success) router.push("/projects");
-    });
+  const confirmDelete = async () => {
     setShowDeleteModal(false);
+    const success = await deleteProject(parseInt(id!));
+    if (success) {
+      router.push("/projects");
+    }
   };
 
   const toggleLanguage = (lang: Language) => {
@@ -91,6 +142,12 @@ export default function ProjectFormScreen() {
       ? current.filter((l) => l !== lang)
       : [...current, lang];
     setFormData({ ...formData, supported_languages: newLanguages });
+  };
+
+  // Helper for border class
+  const getBorderClass = (fieldName: string) => {
+    if (fieldErrors[fieldName]) return "border-red-500";
+    return "border-gray-300";
   };
 
   if (isLoading) {
@@ -113,35 +170,54 @@ export default function ProjectFormScreen() {
         <View className="mb-5">
           <Text className="text-sm font-medium text-gray-700 mb-2">{t("project_name")}</Text>
           <TextInput
-            className="bg-white border border-gray-300 p-3 rounded-lg"
+            className={`bg-white border p-3 rounded-lg ${getBorderClass("name")}`}
             value={formData.name}
             onChangeText={(text) => setFormData({ ...formData, name: text })}
             placeholder={t("project_name")}
           />
+          {fieldErrors.name && (
+            <Text className="text-red-500 text-xs mt-1">{fieldErrors.name}</Text>
+          )}
         </View>
 
         <View className="mb-5 flex-row gap-4">
           <View className="flex-1">
             <Text className="text-sm font-medium text-gray-700 mb-2">{t("max_attempts")}</Text>
             <TextInput
-              className="bg-white border border-gray-300 p-3 rounded-lg"
+              className={`bg-white border p-3 rounded-lg ${getBorderClass("max_cascade_attempts")}`}
               value={formData.max_cascade_attempts.toString()}
               onChangeText={(text) =>
                 setFormData({ ...formData, max_cascade_attempts: parseInt(text) || 0 })
               }
               keyboardType="numeric"
             />
+            <Text className="text-xs text-gray-500 mt-1">
+              {PROJECT_CONSTRAINTS.MAX_CASCADE_ATTEMPTS_MIN}-
+              {PROJECT_CONSTRAINTS.MAX_CASCADE_ATTEMPTS_MAX}
+            </Text>
+            {fieldErrors.max_cascade_attempts && (
+              <Text className="text-red-500 text-xs mt-1">{fieldErrors.max_cascade_attempts}</Text>
+            )}
           </View>
           <View className="flex-1">
             <Text className="text-sm font-medium text-gray-700 mb-2">{t("cascade_timeout")}</Text>
             <TextInput
-              className="bg-white border border-gray-300 p-3 rounded-lg"
+              className={`bg-white border p-3 rounded-lg ${getBorderClass("cascade_timeout_minutes")}`}
               value={formData.cascade_timeout_minutes.toString()}
               onChangeText={(text) =>
                 setFormData({ ...formData, cascade_timeout_minutes: parseInt(text) || 0 })
               }
               keyboardType="numeric"
             />
+            <Text className="text-xs text-gray-500 mt-1">
+              {PROJECT_CONSTRAINTS.CASCADE_TIMEOUT_MINUTES_MIN}-
+              {PROJECT_CONSTRAINTS.CASCADE_TIMEOUT_MINUTES_MAX} min
+            </Text>
+            {fieldErrors.cascade_timeout_minutes && (
+              <Text className="text-red-500 text-xs mt-1">
+                {fieldErrors.cascade_timeout_minutes}
+              </Text>
+            )}
           </View>
         </View>
 
@@ -177,6 +253,9 @@ export default function ProjectFormScreen() {
               />
             </View>
           </View>
+          {fieldErrors.supported_languages && (
+            <Text className="text-red-500 text-xs mt-2">{fieldErrors.supported_languages}</Text>
+          )}
         </View>
 
         <View className="mt-6 gap-3">

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -19,5 +19,17 @@
   "cancel": "Cancel",
   "delete": "Delete",
   "confirm_delete": "Confirm Delete",
-  "delete_confirm_message": "Are you sure you want to delete"
+  "delete_confirm_message": "Are you sure you want to delete",
+  "validation": {
+    "name_required": "Name is required",
+    "name_min_length": "Name must be at least 2 characters",
+    "name_max_length": "Name must be at most 100 characters",
+    "max_attempts_required": "Max attempts is required",
+    "max_attempts_min": "Max attempts must be at least 1",
+    "max_attempts_max": "Max attempts must be at most 10",
+    "timeout_required": "Timeout is required",
+    "timeout_min": "Timeout must be at least 1 minute",
+    "timeout_max": "Timeout must be at most 120 minutes",
+    "supported_languages_required": "At least one language is required"
+  }
 }

--- a/apps/mobile/src/i18n/locales/es.json
+++ b/apps/mobile/src/i18n/locales/es.json
@@ -19,5 +19,17 @@
   "cancel": "Cancelar",
   "delete": "Eliminar",
   "confirm_delete": "Confirmar Eliminación",
-  "delete_confirm_message": "¿Estás seguro de que deseas eliminar"
+  "delete_confirm_message": "¿Estás seguro de que deseas eliminar",
+  "validation": {
+    "name_required": "El nombre es requerido",
+    "name_min_length": "El nombre debe tener al menos 2 caracteres",
+    "name_max_length": "El nombre debe tener como máximo 100 caracteres",
+    "max_attempts_required": "Los intentos máximos son requeridos",
+    "max_attempts_min": "Los intentos mínimos deben ser al menos 1",
+    "max_attempts_max": "Los intentos máximos deben ser como máximo 10",
+    "timeout_required": "El timeout es requerido",
+    "timeout_min": "El timeout debe ser de al menos 1 minuto",
+    "timeout_max": "El timeout debe ser como máximo 120 minutos",
+    "supported_languages_required": "Se requiere al menos un idioma"
+  }
 }

--- a/apps/mobile/src/services/project.service.ts
+++ b/apps/mobile/src/services/project.service.ts
@@ -1,4 +1,4 @@
-import { Project } from "@repo/shared";
+import { Project, CreateProjectSchema, UpdateProjectSchema } from "@repo/shared";
 import { MOCK_PROJECTS } from "../mocks/projects";
 import { logger } from "./logger.service";
 
@@ -13,9 +13,24 @@ const API_URL = process.env.EXPO_PUBLIC_API_URL;
 interface ProjectServiceInterface {
   getProjects(): Promise<Project[]>;
   getProjectById(id: number): Promise<Project | null>;
-  createProject(project: Omit<Project, "id">): Promise<Project>;
-  updateProject(id: number, project: Partial<Project>): Promise<Project>;
+  createProject(project: CreateProjectSchema.infer): Promise<Project>;
+  updateProject(id: number, project: UpdateProjectSchema.infer): Promise<Project>;
   deleteProject(id: number): Promise<boolean>;
+}
+
+/**
+ * Validate project data using Zod schemas
+ */
+function validateProjectData(
+  data: unknown,
+  schema: typeof CreateProjectSchema | typeof UpdateProjectSchema,
+) {
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    const errors = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join(", ");
+    throw new Error(`Validation failed: ${errors}`);
+  }
+  return result.data;
 }
 
 /**
@@ -35,10 +50,12 @@ const MockProjectService: ProjectServiceInterface = {
     return mockProjects.find((p) => p.id === id) || null;
   },
 
-  createProject: async (project: Omit<Project, "id">) => {
+  createProject: async (project: CreateProjectSchema.infer) => {
     await new Promise((r) => setTimeout(r, 800));
+    // Validate input
+    const validated = validateProjectData(project, CreateProjectSchema);
     const newProject: Project = {
-      ...project,
+      ...validated,
       id: nextId++,
     };
     mockProjects = [...mockProjects, newProject];
@@ -46,13 +63,15 @@ const MockProjectService: ProjectServiceInterface = {
     return newProject;
   },
 
-  updateProject: async (id: number, project: Partial<Project>) => {
+  updateProject: async (id: number, project: UpdateProjectSchema.infer) => {
     await new Promise((r) => setTimeout(r, 800));
     const index = mockProjects.findIndex((p) => p.id === id);
     if (index === -1) {
       throw new Error("Project not found");
     }
-    const updatedProject = { ...mockProjects[index], ...project };
+    // Validate input
+    const validated = validateProjectData(project, UpdateProjectSchema);
+    const updatedProject = { ...mockProjects[index], ...validated };
     mockProjects = mockProjects.map((p) => (p.id === id ? updatedProject : p));
     logger.info("[MOCK API] Updated project:", updatedProject);
     return updatedProject;

--- a/packages/shared/src/types/project.ts
+++ b/packages/shared/src/types/project.ts
@@ -1,14 +1,46 @@
 import { z } from "zod";
 import { LanguageSchema } from "./common";
 
+export const PROJECT_CONSTRAINTS = {
+  MAX_CASCADE_ATTEMPTS_MIN: 1,
+  MAX_CASCADE_ATTEMPTS_MAX: 10,
+  CASCADE_TIMEOUT_MINUTES_MIN: 1,
+  CASCADE_TIMEOUT_MINUTES_MAX: 120,
+  NAME_MIN_LENGTH: 2,
+  NAME_MAX_LENGTH: 100,
+} as const;
+
 export const ProjectSchema = z.object({
   id: z.number().int().positive(),
-  name: z.string().min(2),
+  name: z
+    .string()
+    .min(PROJECT_CONSTRAINTS.NAME_MIN_LENGTH)
+    .max(PROJECT_CONSTRAINTS.NAME_MAX_LENGTH),
   default_language: LanguageSchema.default("es"),
-  supported_languages: z.array(LanguageSchema).default(["es"]),
-  cascade_timeout_minutes: z.number().int().positive().default(30),
-  max_cascade_attempts: z.number().int().positive().default(10),
+  supported_languages: z.array(LanguageSchema).min(1).default(["es"]),
+  cascade_timeout_minutes: z
+    .number()
+    .int()
+    .min(PROJECT_CONSTRAINTS.CASCADE_TIMEOUT_MINUTES_MIN)
+    .max(PROJECT_CONSTRAINTS.CASCADE_TIMEOUT_MINUTES_MAX)
+    .default(30),
+  max_cascade_attempts: z
+    .number()
+    .int()
+    .min(PROJECT_CONSTRAINTS.MAX_CASCADE_ATTEMPTS_MIN)
+    .max(PROJECT_CONSTRAINTS.MAX_CASCADE_ATTEMPTS_MAX)
+    .default(10),
   is_active: z.boolean().default(true),
 });
 
+// Schema for creating a new project (without id)
+export const CreateProjectSchema = ProjectSchema.omit({ id: true });
+
+// Schema for updating a project (all fields optional)
+export const UpdateProjectSchema = CreateProjectSchema.partial();
+
 export interface Project extends z.infer<typeof ProjectSchema> {}
+
+export interface CreateProjectInput extends z.infer<typeof CreateProjectSchema> {}
+
+export interface UpdateProjectInput extends z.infer<typeof UpdateProjectSchema> {}


### PR DESCRIPTION
## Summary

Adds field-level validation to the project form and fixes Android navigator context error that occurred during validation.

- Add PROJECT_CONSTRAINTS with min/max values in shared package
- Add CreateProjectSchema and UpdateProjectSchema for Zod validation
- Validate input in service layer before saving
- Validate form in UI with field-level error display
- Show i18n validation messages for all fields
- Add supported_languages min(1) validation
- Simplify validation to avoid Android navigator context error

Closes #25

## Changes

| File | Change |
|------|--------|
| `packages/shared/src/types/project.ts` | Add PROJECT_CONSTRAINTS and schemas |
| `apps/mobile/src/services/project.service.ts` | Add Zod validation before save |
| `apps/mobile/src/app/projects/[id].tsx` | Add field-level validation UI |
| `apps/mobile/src/i18n/locales/en.json` | Add validation messages |
| `apps/mobile/src/i18n/locales/es.json` | Add validation messages |

## Test Plan

- [x] Web: validation works with i18n messages
- [x] Android: no navigator context error on save with validation errors
- [x] GGA code review passes

## Checklist

- [x] Linked issue #25
- [x] Conventional commit format
- [x] No Co-Authored-By trailers