### PR TITLE
feat(mobile): add reusable form components

### DIFF
--- a/apps/mobile/src/app/projects/[id].tsx
+++ b/apps/mobile/src/app/projects/[id].tsx
@@ -1,11 +1,14 @@
 import { useState, useEffect } from "react";
-import { View, Text, TextInput, Switch, Pressable, ActivityIndicator } from "react-native";
+import { View, Text, ActivityIndicator } from "react-native";
 import { useRouter, useLocalSearchParams } from "expo-router";
 import { useProjectStore } from "../../stores/project.store";
 import { useI18n } from "../../hooks/useI18n";
 import { Project, Language, PROJECT_CONSTRAINTS, CreateProjectSchema } from "@repo/shared";
 import { Button } from "../../components/Button";
 import { ConfirmModal } from "../../components/ConfirmModal";
+import { FormInput } from "../../components/FormInput";
+import { FormSwitch } from "../../components/FormSwitch";
+import { FormLanguageSelector } from "../../components/FormLanguageSelector";
 
 interface ProjectFormData extends Omit<Project, "id"> {}
 
@@ -144,12 +147,6 @@ export default function ProjectFormScreen() {
     setFormData({ ...formData, supported_languages: newLanguages });
   };
 
-  // Helper for border class
-  const getBorderClass = (fieldName: string) => {
-    if (fieldErrors[fieldName]) return "border-red-500";
-    return "border-gray-300";
-  };
-
   if (isLoading) {
     return (
       <View className="flex-1 bg-gray-50 p-5 pt-20 items-center justify-center">
@@ -167,96 +164,54 @@ export default function ProjectFormScreen() {
           </Text>
         </View>
 
-        <View className="mb-5">
-          <Text className="text-sm font-medium text-gray-700 mb-2">{t("project_name")}</Text>
-          <TextInput
-            className={`bg-white border p-3 rounded-lg ${getBorderClass("name")}`}
-            value={formData.name}
-            onChangeText={(text) => setFormData({ ...formData, name: text })}
-            placeholder={t("project_name")}
-          />
-          {fieldErrors.name && (
-            <Text className="text-red-500 text-xs mt-1">{fieldErrors.name}</Text>
-          )}
-        </View>
+        <FormInput
+          label={t("project_name")}
+          value={formData.name}
+          onChangeText={(text) => setFormData({ ...formData, name: text })}
+          placeholder={t("project_name")}
+          error={fieldErrors.name}
+        />
 
         <View className="mb-5 flex-row gap-4">
           <View className="flex-1">
-            <Text className="text-sm font-medium text-gray-700 mb-2">{t("max_attempts")}</Text>
-            <TextInput
-              className={`bg-white border p-3 rounded-lg ${getBorderClass("max_cascade_attempts")}`}
+            <FormInput
+              label={t("max_attempts")}
               value={formData.max_cascade_attempts.toString()}
               onChangeText={(text) =>
                 setFormData({ ...formData, max_cascade_attempts: parseInt(text) || 0 })
               }
               keyboardType="numeric"
+              helperText={`${PROJECT_CONSTRAINTS.MAX_CASCADE_ATTEMPTS_MIN}-${PROJECT_CONSTRAINTS.MAX_CASCADE_ATTEMPTS_MAX}`}
+              error={fieldErrors.max_cascade_attempts}
             />
-            <Text className="text-xs text-gray-500 mt-1">
-              {PROJECT_CONSTRAINTS.MAX_CASCADE_ATTEMPTS_MIN}-
-              {PROJECT_CONSTRAINTS.MAX_CASCADE_ATTEMPTS_MAX}
-            </Text>
-            {fieldErrors.max_cascade_attempts && (
-              <Text className="text-red-500 text-xs mt-1">{fieldErrors.max_cascade_attempts}</Text>
-            )}
           </View>
           <View className="flex-1">
-            <Text className="text-sm font-medium text-gray-700 mb-2">{t("cascade_timeout")}</Text>
-            <TextInput
-              className={`bg-white border p-3 rounded-lg ${getBorderClass("cascade_timeout_minutes")}`}
+            <FormInput
+              label={t("cascade_timeout")}
               value={formData.cascade_timeout_minutes.toString()}
               onChangeText={(text) =>
                 setFormData({ ...formData, cascade_timeout_minutes: parseInt(text) || 0 })
               }
               keyboardType="numeric"
+              helperText={`${PROJECT_CONSTRAINTS.CASCADE_TIMEOUT_MINUTES_MIN}-${PROJECT_CONSTRAINTS.CASCADE_TIMEOUT_MINUTES_MAX} min`}
+              error={fieldErrors.cascade_timeout_minutes}
             />
-            <Text className="text-xs text-gray-500 mt-1">
-              {PROJECT_CONSTRAINTS.CASCADE_TIMEOUT_MINUTES_MIN}-
-              {PROJECT_CONSTRAINTS.CASCADE_TIMEOUT_MINUTES_MAX} min
-            </Text>
-            {fieldErrors.cascade_timeout_minutes && (
-              <Text className="text-red-500 text-xs mt-1">
-                {fieldErrors.cascade_timeout_minutes}
-              </Text>
-            )}
           </View>
         </View>
 
-        <View className="mb-5">
-          <Text className="text-sm font-medium text-gray-700 mb-2">{t("supported_languages")}</Text>
-          <View className="flex-row gap-4 items-center">
-            <View className="flex-row gap-2">
-              {(["es", "en"] as Language[]).map((lang) => (
-                <Pressable
-                  key={lang}
-                  className={`px-4 py-2 rounded-lg border ${
-                    formData.supported_languages.includes(lang)
-                      ? "bg-green-600 border-green-600"
-                      : "bg-white border-gray-300"
-                  }`}
-                  onPress={() => toggleLanguage(lang)}
-                >
-                  <Text
-                    className={
-                      formData.supported_languages.includes(lang) ? "text-white" : "text-gray-700"
-                    }
-                  >
-                    {lang.toUpperCase()}
-                  </Text>
-                </Pressable>
-              ))}
-            </View>
-            <View className="flex-row items-center gap-2 ml-auto">
-              <Text className="text-sm text-gray-700">{t("active")}</Text>
-              <Switch
-                value={formData.is_active}
-                onValueChange={(value) => setFormData({ ...formData, is_active: value })}
-              />
-            </View>
-          </View>
-          {fieldErrors.supported_languages && (
-            <Text className="text-red-500 text-xs mt-2">{fieldErrors.supported_languages}</Text>
-          )}
-        </View>
+        <FormLanguageSelector
+          label={t("supported_languages")}
+          selectedLanguages={formData.supported_languages}
+          onToggle={toggleLanguage}
+          extra={
+            <FormSwitch
+              label={t("active")}
+              value={formData.is_active}
+              onValueChange={(value) => setFormData({ ...formData, is_active: value })}
+            />
+          }
+          error={fieldErrors.supported_languages}
+        />
 
         <View className="mt-6 gap-3">
           <Button

--- a/apps/mobile/src/app/projects/index.tsx
+++ b/apps/mobile/src/app/projects/index.tsx
@@ -3,7 +3,7 @@ import { useFocusEffect, useRouter, Link } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { Text, View, ActivityIndicator } from "react-native";
 import { useProjectStore } from "../../stores/project.store";
-import { useI18n, useLocale } from "../../hooks/useI18n";
+import { useI18n } from "../../hooks/useI18n";
 import { Project } from "@repo/shared";
 import { Button } from "../../components/Button";
 import { LanguageSwitcher } from "../../components/LanguageSwitcher";

--- a/apps/mobile/src/components/Button.tsx
+++ b/apps/mobile/src/components/Button.tsx
@@ -1,16 +1,19 @@
-import { Pressable, Text, ActivityIndicator, ViewStyle, TextStyle } from "react-native";
+import { Pressable, Text } from "react-native";
 
-type ButtonVariant = "primary" | "secondary" | "danger";
+interface ButtonVariant {
+  container: string;
+  text: string;
+}
 
 interface ButtonProps {
   title: string;
-  variant?: ButtonVariant;
+  variant?: "primary" | "secondary" | "danger";
   onPress: () => void;
   disabled?: boolean;
   icon?: string;
 }
 
-const variantStyles: Record<ButtonVariant, { container: string; text: string }> = {
+const variantStyles: Record<string, ButtonVariant> = {
   primary: {
     container: "bg-green-600",
     text: "text-white",

--- a/apps/mobile/src/components/FormInput.tsx
+++ b/apps/mobile/src/components/FormInput.tsx
@@ -1,0 +1,34 @@
+import { Text, TextInput, View, TextInputProps } from "react-native";
+
+interface FormInputProps extends Omit<TextInputProps, "className"> {
+  label: string;
+  error?: string;
+  helperText?: string;
+}
+
+export function FormInput({
+  label,
+  error,
+  helperText,
+  value,
+  onChangeText,
+  keyboardType,
+  placeholder,
+  ...rest
+}: FormInputProps) {
+  return (
+    <View className="mb-5">
+      <Text className="text-sm font-medium text-gray-700 mb-2">{label}</Text>
+      <TextInput
+        className={`bg-white border p-3 rounded-lg ${error ? "border-red-500" : "border-gray-300"}`}
+        value={value}
+        onChangeText={onChangeText}
+        keyboardType={keyboardType}
+        placeholder={placeholder}
+        {...rest}
+      />
+      {helperText && <Text className="text-xs text-gray-500 mt-1">{helperText}</Text>}
+      {error && <Text className="text-red-500 text-xs mt-1">{error}</Text>}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/FormLanguageSelector.tsx
+++ b/apps/mobile/src/components/FormLanguageSelector.tsx
@@ -1,0 +1,48 @@
+import { ReactNode } from "react";
+import { Text, View, Pressable } from "react-native";
+import { Language } from "@repo/shared";
+
+interface FormLanguageSelectorProps {
+  label: string;
+  selectedLanguages: Language[];
+  onToggle: (lang: Language) => void;
+  availableLanguages?: Language[];
+  extra?: ReactNode;
+  error?: string;
+}
+
+export function FormLanguageSelector({
+  label,
+  selectedLanguages,
+  onToggle,
+  availableLanguages = ["es", "en"],
+  extra,
+  error,
+}: FormLanguageSelectorProps) {
+  return (
+    <View className="mb-5">
+      <Text className="text-sm font-medium text-gray-700 mb-2">{label}</Text>
+      <View className="flex-row gap-4 items-center">
+        <View className="flex-row gap-2">
+          {availableLanguages.map((lang) => (
+            <Pressable
+              key={lang}
+              className={`px-4 py-2 rounded-lg border ${
+                selectedLanguages.includes(lang)
+                  ? "bg-green-600 border-green-600"
+                  : "bg-white border-gray-300"
+              }`}
+              onPress={() => onToggle(lang)}
+            >
+              <Text className={selectedLanguages.includes(lang) ? "text-white" : "text-gray-700"}>
+                {lang.toUpperCase()}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+        {extra && <View className="ml-auto">{extra}</View>}
+      </View>
+      {error && <Text className="text-red-500 text-xs mt-2">{error}</Text>}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/FormSwitch.tsx
+++ b/apps/mobile/src/components/FormSwitch.tsx
@@ -1,0 +1,14 @@
+import { Text, View, Switch, SwitchProps } from "react-native";
+
+interface FormSwitchProps extends Omit<SwitchProps, "className"> {
+  label: string;
+}
+
+export function FormSwitch({ label, value, onValueChange, ...rest }: FormSwitchProps) {
+  return (
+    <View className="flex-row items-center gap-2">
+      <Text className="text-sm text-gray-700">{label}</Text>
+      <Switch value={value} onValueChange={onValueChange} {...rest} />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary

Add reusable form components to reduce code duplication in forms.

- Add FormInput component with label, error, helperText
- Add FormSwitch component for toggle inputs
- Add FormLanguageSelector component for language selection
- Refactor project form to use new components

Closes #26

## Changes

| File | Change |
|------|--------|
| `apps/mobile/src/components/FormInput.tsx` | New reusable input component |
| `apps/mobile/src/components/FormSwitch.tsx` | New reusable switch component |
| `apps/mobile/src/components/FormLanguageSelector.tsx` | New reusable language selector |
| `apps/mobile/src/app/projects/[id].tsx` | Refactored to use new components |
| `apps/mobile/src/components/Button.tsx` | Fixed interface vs type alias |

## Test Plan

- [x] make check passes
- [x] GGA code review passes
- [x] Tested in browser

## Checklist

- [x] Linked issue #26
- [x] Conventional commit format
- [x] No Co-Authored-By trailers