### PR TITLE
feat: role-based tab navigation

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,75 +1,71 @@
 import { ConfigContext, ExpoConfig } from "expo/config";
 
-const IS_DEV = process.env.APP_VARIANT === 'development';
-const IS_PREVIEW = process.env.APP_VARIANT === 'preview';
+const IS_DEV = process.env.APP_VARIANT === "development";
+const IS_PREVIEW = process.env.APP_VARIANT === "preview";
 
 const getUniqueIdentifier = () => {
   if (IS_DEV) {
-    return 'org.impenetrable.connect.dev';
+    return "org.impenetrable.connect.dev";
   }
 
   if (IS_PREVIEW) {
-    return 'org.impenetrable.connect.preview';
+    return "org.impenetrable.connect.preview";
   }
 
-  return 'org.impenetrable.connect';
+  return "org.impenetrable.connect";
 };
 
 const getAppName = () => {
   if (IS_DEV) {
-    return 'Impenetrable Connect (Dev)';
+    return "Impenetrable Connect (Dev)";
   }
 
   if (IS_PREVIEW) {
-    return 'Impenetrable Connect (Preview)';
+    return "Impenetrable Connect (Preview)";
   }
 
-  return 'Impenetrable Connect';
+  return "Impenetrable Connect";
 };
-
 
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
-  "name": getAppName(),
-  "slug": "impenetrable-connect",
-  "version": "1.0.0",
-  "orientation": "portrait",
-  "icon": "./assets/icon.png",
-  "scheme": "impenetrable-connect",
-  "userInterfaceStyle": "light",
-  "splash": {
-    "image": "./assets/splash-icon.png",
-    "resizeMode": "contain",
-    "backgroundColor": "#fcf9f2"
+  name: getAppName(),
+  slug: "impenetrable-connect",
+  version: "1.0.0",
+  orientation: "portrait",
+  icon: "./assets/icon.png",
+  scheme: "impenetrable-connect",
+  userInterfaceStyle: "light",
+  splash: {
+    image: "./assets/splash-icon.png",
+    resizeMode: "contain",
+    backgroundColor: "#fcf9f2", // Uses surface color from design system
   },
-  "plugins": [
-    "expo-localization",
-    "expo-router"
-  ],
-  "ios": {
-    "supportsTablet": true,
-    "bundleIdentifier": getUniqueIdentifier(),
-    "infoPlist": {
-      "ITSAppUsesNonExemptEncryption": false
-    }
-  },
-  "android": {
-    "adaptiveIcon": {
-      "foregroundImage": "./assets/adaptive-icon.png",
-      "backgroundColor": "#fcf9f2"
+  plugins: ["expo-localization", "expo-router"],
+  ios: {
+    supportsTablet: true,
+    bundleIdentifier: getUniqueIdentifier(),
+    infoPlist: {
+      ITSAppUsesNonExemptEncryption: false,
     },
-    "predictiveBackGestureEnabled": false,
-    "package": getUniqueIdentifier()
   },
-  "web": {
-    "bundler": "metro",
-    "favicon": "./assets/favicon.png"
+  android: {
+    adaptiveIcon: {
+      foregroundImage: "./assets/adaptive-icon.png",
+      backgroundColor: "#fcf9f2",
+    },
+    predictiveBackGestureEnabled: false,
+    package: getUniqueIdentifier(),
   },
-  "extra": {
-    "router": {},
-    "eas": {
-      "projectId": "430a65eb-19e4-4158-9822-475364cb6664"
-    }
+  web: {
+    bundler: "metro",
+    favicon: "./assets/favicon.png",
   },
-  "owner": "masch"
-})
+  extra: {
+    router: {},
+    eas: {
+      projectId: "430a65eb-19e4-4158-9822-475364cb6664",
+    },
+  },
+  owner: "masch",
+});

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -21,7 +21,8 @@
       "distribution": "internal",
       "env": {
         "APP_VARIANT": "preview"
-      }
+      },
+      "autoIncrement": true
     },
     "production": {
       "autoIncrement": true

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@expo/metro-config": "~55.0.9",
+    "@expo/vector-icons": "^15.1.1",
     "@repo/shared": "workspace:*",
     "expo": "~55.0.0",
     "expo-constants": "~55.0.11",

--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -1,15 +1,96 @@
-import { NativeTabs } from "expo-router/unstable-native-tabs";
+import { useEffect, useState, useMemo } from "react";
+import { Tabs } from "expo-router";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { UserRole } from "@repo/shared";
+import { useAuthStore } from "../../stores/auth.store";
+
+type IconName = keyof typeof MaterialCommunityIcons.glyphMap;
+
+interface TabItem {
+  name: string;
+  label: string;
+  icon: IconName;
+}
+
+// Tabs organized by user role - keep this structure
+const tabsByRole: Record<UserRole, TabItem[]> = {
+  TOURIST: [
+    { name: "role-selector", label: "Dev", icon: "wrench" },
+    { name: "tourist/catalog", label: "Catalog", icon: "view-grid" },
+    { name: "tourist/order", label: "Order", icon: "cart" },
+    { name: "profile", label: "Profile", icon: "account-circle" },
+  ],
+  ENTREPRENEUR: [
+    { name: "role-selector", label: "Dev", icon: "wrench" },
+    { name: "entrepreneur/request", label: "Request", icon: "file-document" },
+    { name: "entrepreneur/agenda", label: "Agenda", icon: "calendar" },
+    { name: "profile", label: "Profile", icon: "account-circle" },
+  ],
+  ADMIN: [
+    { name: "role-selector", label: "Dev", icon: "wrench" },
+    { name: "admin/project", label: "Projects", icon: "folder" },
+    { name: "profile", label: "Profile", icon: "account-circle" },
+  ],
+};
 
 export default function TabsLayout() {
+  const userRole = useAuthStore((state) => state.userRole);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Get current role tabs
+  const currentTabs = tabsByRole[userRole] ?? tabsByRole["TOURIST"];
+  const currentTabNames = useMemo(() => currentTabs.map((t) => t.name), [currentTabs]);
+
+  if (!mounted) {
+    return null;
+  }
+
+  // Get unique tabs from all roles (deduplicate by name)
+  const allTabs = Object.values(tabsByRole).flat();
+  const uniqueTabs = allTabs.filter(
+    (tab, index, self) => self.findIndex((t) => t.name === tab.name) === index,
+  );
+
   return (
-    <NativeTabs tintColor="primary">
-      <NativeTabs.Trigger name="project">
-        <NativeTabs.Trigger.Label>Projects</NativeTabs.Trigger.Label>
-        <NativeTabs.Trigger.Icon
-          sf={{ default: "list.bullet", selected: "list.bullet" }}
-          md="list"
-        />
-      </NativeTabs.Trigger>
-    </NativeTabs>
+    <Tabs
+      screenOptions={{
+        tabBarActiveTintColor: "primary",
+        tabBarInactiveTintColor: "tab-inactive",
+        tabBarStyle: { backgroundColor: "surface" },
+        headerShown: false,
+      }}
+    >
+      {uniqueTabs.map((tab) => {
+        const isVisible = currentTabNames.includes(tab.name);
+
+        return (
+          <Tabs.Screen
+            key={tab.name}
+            name={tab.name}
+            options={{
+              tabBarItemStyle: isVisible ? undefined : { display: "none" },
+              title: tab.label,
+              tabBarLabel: tab.label,
+              tabBarIcon: ({ color, size }) => {
+                // Cast to the expected icon type
+                const iconName =
+                  tab.icon as typeof MaterialCommunityIcons extends React.ComponentType<infer P>
+                    ? P extends { name: infer N }
+                      ? N
+                      : never
+                    : never;
+                return (
+                  <MaterialCommunityIcons name={iconName || "circle"} size={size} color={color} />
+                );
+              },
+            }}
+          />
+        );
+      })}
+    </Tabs>
   );
 }

--- a/apps/mobile/src/app/(tabs)/admin/project.tsx
+++ b/apps/mobile/src/app/(tabs)/admin/project.tsx
@@ -2,11 +2,11 @@ import { useCallback } from "react";
 import { useFocusEffect, useRouter, Link } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { Text, View, ActivityIndicator, ScrollView } from "react-native";
-import { useProjectStore } from "../../stores/project.store";
-import { useI18n } from "../../hooks/useI18n";
+import { useProjectStore } from "../../../stores/project.store";
+import { useI18n } from "../../../hooks/useI18n";
 import { Project } from "@repo/shared";
-import { Button } from "../../components/Button";
-import { LanguageSwitcher } from "../../components/LanguageSwitcher";
+import { Button } from "../../../components/Button";
+import { LanguageSwitcher } from "../../../components/LanguageSwitcher";
 
 interface ProjectCardProps {
   project: Project;
@@ -156,7 +156,17 @@ export default function ProjectsScreen() {
 
   return (
     <View className="flex-1 bg-surface pt-20 px-5">
-      <View className="flex-1 max-w-md w-full mx-auto">
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{
+          flexGrow: 1,
+          maxWidth: 448,
+          width: "100%",
+          alignSelf: "center",
+          paddingBottom: 24,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
         {/* Header */}
         <View className="mb-8 flex-row justify-between items-center">
           <View className="flex-1">
@@ -170,63 +180,56 @@ export default function ProjectsScreen() {
           <LanguageSwitcher />
         </View>
 
-        {/* Content - scrollable */}
-        <ScrollView
-          className="pt-8 flex-1"
-          contentContainerStyle={{ flexGrow: 1 }}
-          showsVerticalScrollIndicator={false}
-        >
-          {/* Loading State */}
-          {isLoading && (
-            <View className="py-12 items-center">
-              <ActivityIndicator size="large" color="#2b868c" />
-              <Text className="text-on-surface mt-4">{t("loading")}</Text>
-            </View>
-          )}
+        {/* Loading State */}
+        {isLoading && (
+          <View className="py-12 items-center">
+            <ActivityIndicator size="large" color="#2b868c" />
+            <Text className="text-on-surface mt-4">{t("loading")}</Text>
+          </View>
+        )}
 
-          {/* Active Projects */}
-          {!isLoading && !error && activeProjects.length > 0 && (
-            <View className="mb-8">
-              <Text className="text-lg font-bold text-on-surface mb-4">{t("active_projects")}</Text>
-              <View className="items-center">
-                {activeProjects.map((project) => (
-                  <ActiveProjectCard key={project.id} project={project} />
-                ))}
-              </View>
+        {/* Active Projects */}
+        {!isLoading && !error && activeProjects.length > 0 && (
+          <View className="mb-8">
+            <Text className="text-lg font-bold text-on-surface mb-4">{t("active_projects")}</Text>
+            <View className="items-center">
+              {activeProjects.map((project) => (
+                <ActiveProjectCard key={project.id} project={project} />
+              ))}
             </View>
-          )}
+          </View>
+        )}
 
-          {/* Inactive Projects */}
-          {!isLoading && !error && inactiveProjects.length > 0 && (
-            <View className="mb-8">
-              <Text className="text-lg font-bold text-on-surface opacity-50 mb-4">
-                {t("inactive_projects")}
-              </Text>
-              <View className="items-center">
-                {inactiveProjects.map((project) => (
-                  <InactiveProjectCard key={project.id} project={project} />
-                ))}
-              </View>
+        {/* Inactive Projects */}
+        {!isLoading && !error && inactiveProjects.length > 0 && (
+          <View className="mb-8">
+            <Text className="text-lg font-bold text-on-surface opacity-50 mb-4">
+              {t("inactive_projects")}
+            </Text>
+            <View className="items-center">
+              {inactiveProjects.map((project) => (
+                <InactiveProjectCard key={project.id} project={project} />
+              ))}
             </View>
-          )}
+          </View>
+        )}
 
-          {/* Empty State */}
-          {!isLoading && !error && projects.length === 0 && (
-            <Text className="text-on-surface text-center mb-6 opacity-60">{t("no_projects")}</Text>
-          )}
+        {/* Empty State */}
+        {!isLoading && !error && projects.length === 0 && (
+          <Text className="text-on-surface text-center mb-6 opacity-60">{t("no_projects")}</Text>
+        )}
 
-          {/* Action Button */}
-          {!isLoading && (
-            <View className="pt-8 pb-8">
-              <Button
-                title={t("add_project")}
-                icon="+"
-                onPress={() => router.push("/projects/new")}
-              />
-            </View>
-          )}
-        </ScrollView>
-      </View>
+        {/* Action Button */}
+        {!isLoading && (
+          <View className="pt-8 pb-8">
+            <Button
+              title={t("add_project")}
+              icon="+"
+              onPress={() => router.push("/projects/new")}
+            />
+          </View>
+        )}
+      </ScrollView>
 
       <StatusBar style="auto" />
     </View>

--- a/apps/mobile/src/app/(tabs)/entrepreneur/agenda.tsx
+++ b/apps/mobile/src/app/(tabs)/entrepreneur/agenda.tsx
@@ -1,0 +1,5 @@
+import Screen from "../../../components/Screen";
+
+export default function AgendaScreen() {
+  return <Screen title="Agenda"></Screen>;
+}

--- a/apps/mobile/src/app/(tabs)/entrepreneur/request.tsx
+++ b/apps/mobile/src/app/(tabs)/entrepreneur/request.tsx
@@ -1,0 +1,5 @@
+import Screen from "../../../components/Screen";
+
+export default function RequestScreen() {
+  return <Screen title="Request"></Screen>;
+}

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -1,0 +1,5 @@
+import Screen from "../../components/Screen";
+
+export default function ProfileScreen() {
+  return <Screen title="Profile"></Screen>;
+}

--- a/apps/mobile/src/app/(tabs)/role-selector.tsx
+++ b/apps/mobile/src/app/(tabs)/role-selector.tsx
@@ -1,0 +1,53 @@
+import { useAuthStore } from "../../stores/auth.store";
+import { UserRole } from "@repo/shared";
+import { Button } from "../../components/Button";
+import { View, Text } from "react-native";
+
+const ROLES: { role: UserRole; label: string; description: string }[] = [
+  {
+    role: "TOURIST",
+    label: "Tourist",
+    description: "Browse catalog and place orders",
+  },
+  {
+    role: "ENTREPRENEUR",
+    label: "Entrepreneur",
+    description: "Manage requests and agenda",
+  },
+  {
+    role: "ADMIN",
+    label: "Admin",
+    description: "Manage projects",
+  },
+];
+
+export default function RoleSelectorScreen() {
+  const { userRole, setUserRole } = useAuthStore();
+
+  return (
+    <View className="flex-1 bg-surface pt-20 px-5">
+      <View className="flex-1 max-w-md w-full mx-auto">
+        <Text className="text-2xl font-bold text-on-surface mb-1">Select User Role</Text>
+        <Text className="text-sm text-on-surface opacity-60 mb-6">Development mode only</Text>
+
+        <View className="mb-6">
+          {ROLES.map((item) => (
+            <View key={item.role} className="mb-4">
+              <Button
+                title={item.label}
+                variant={userRole === item.role ? "primary" : "secondary"}
+                onPress={() => setUserRole(item.role)}
+              />
+              <Text className="text-xs text-on-surface opacity-60 mt-1">{item.description}</Text>
+            </View>
+          ))}
+        </View>
+
+        <View className="p-4 bg-surface-container-lowest rounded-none flex-row justify-between">
+          <Text className="text-on-surface opacity-60">Current role:</Text>
+          <Text className="font-bold text-on-surface">{userRole}</Text>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/app/(tabs)/tourist/catalog.tsx
+++ b/apps/mobile/src/app/(tabs)/tourist/catalog.tsx
@@ -1,0 +1,5 @@
+import Screen from "../../../components/Screen";
+
+export default function CatalogScreen() {
+  return <Screen title="Catalog"></Screen>;
+}

--- a/apps/mobile/src/app/(tabs)/tourist/order.tsx
+++ b/apps/mobile/src/app/(tabs)/tourist/order.tsx
@@ -1,0 +1,5 @@
+import Screen from "../../../components/Screen";
+
+export default function OrderScreen() {
+  return <Screen title="Order"></Screen>;
+}

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -1,5 +1,14 @@
 import { Redirect } from "expo-router";
+import { useAuthStore } from "../stores/auth.store";
+
+const roleLandingPages = {
+  TOURIST: "/tourist/catalog",
+  ENTREPRENEUR: "/entrepreneur/request",
+  ADMIN: "/admin/project",
+} as const;
 
 export default function Index() {
-  return <Redirect href="/project" />;
+  const { userRole } = useAuthStore();
+  const landingPage = roleLandingPages[userRole] ?? "/tourist/catalog";
+  return <Redirect href={landingPage} />;
 }

--- a/apps/mobile/src/components/Screen.tsx
+++ b/apps/mobile/src/components/Screen.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from "react";
+import { View, Text } from "react-native";
+
+interface ScreenProps {
+  title: string;
+  children?: ReactNode;
+}
+
+export default function Screen({ title, children }: ScreenProps) {
+  return (
+    <View className="flex-1 bg-surface pt-20 px-5">
+      <View className="flex-1 max-w-md w-full mx-auto">
+        <Text className="text-2xl font-bold text-primary mb-6">{title}</Text>
+        {children}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/stores/auth.store.ts
+++ b/apps/mobile/src/stores/auth.store.ts
@@ -1,0 +1,16 @@
+import { create } from "zustand";
+import { UserRole } from "@repo/shared";
+
+interface AuthState {
+  userRole: UserRole;
+  setUserRole: (role: UserRole) => void;
+}
+
+// Mock user for early development - will be replaced with real auth
+export const useAuthStore = create<AuthState>((set) => ({
+  userRole: "TOURIST",
+
+  setUserRole: (role: UserRole) => {
+    set({ userRole: role });
+  },
+}));

--- a/apps/mobile/tailwind.config.js
+++ b/apps/mobile/tailwind.config.js
@@ -38,6 +38,9 @@ module.exports = {
 
         // Outline
         "outline-variant": "#dbc1bb",
+
+        // Tab bar colors
+        "tab-inactive": "#666666",
       },
       fontFamily: {
         // Section 3: Manrope for headlines, Inter for body

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/metro-config": "~55.0.9",
+        "@expo/vector-icons": "^15.1.1",
         "@repo/shared": "workspace:*",
         "expo": "~55.0.0",
         "expo-constants": "~55.0.11",


### PR DESCRIPTION
## Summary

Implemented role-based tab navigation that shows different tabs based on user type (TOURIST, ENTREPRENEUR, ADMIN).

## Changes

- Created  with Zustand for managing user role state
- Added  screen for switching between user types in dev mode
- Refactored  to use standard  instead of  (fixes Android label visibility issue)
- Added role-based tab filtering that hides tabs not belonging to current role
- Added MaterialCommunityIcons for tab bar icons
- Added design tokens for tab bar colors ()
- Removed unused packages: , 

## User Tabs

- **TOURIST**: Dev, Catalog, Order, Profile
- **ENTREPRENEUR**: Dev, Request, Agenda, Profile  
- **ADMIN**: Dev, Projects, Profile

## Testing

- Tested on both web and Android
- Role switching works via the Dev tab

## Notes

- Currently in mock/development mode - auth store uses hardcoded role that can be changed via role selector
- The tab hiding uses  which is required by expo-router