### PR TITLE
feat(mobile): deploy app to web using EAS Hosting for free

### DIFF
--- a/.eas/workflows/deploy-web.yml
+++ b/.eas/workflows/deploy-web.yml
@@ -1,0 +1,31 @@
+name: Deploy Web
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/mobile/**"
+      - "packages/shared/**"
+      - "apps/backend/**"
+      - "!apps/mobile/assets/**"
+      - "!apps/mobile/**/*.md"
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install Dependencies
+        run: bun install
+
+      - name: Export Web Build
+        run: make eas-export-web
+
+      - name: Deploy to EAS Hosting
+        run: make eas-deploy-web-prod

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup install dev clean lint gga format check typecheck mobile mobile-native mobile-clean mobile-web mobile-android mobile-android-native mobile-ios mobile-ios-native mobile-dev mobile-expo-fix-deps mobile-expo-doctor backend seed android-reset android-stop android-kill android-restart eas-login eas-whoami eas-init eas-build-configure eas-build-android-dev eas-build-android-preview eas-build-android-production eas-build-ios-simulator
+.PHONY: help setup install dev clean lint gga format check typecheck mobile mobile-native mobile-clean mobile-web mobile-android mobile-android-native mobile-ios mobile-ios-native mobile-dev mobile-expo-fix-deps mobile-expo-doctor backend seed eas-login eas-whoami eas-init eas-build-configure eas-build-dev eas-build-android-dev eas-build-android-preview eas-build-android-production eas-build-ios-simulator eas-export-web eas-deploy-web eas-deploy-web-prod android-reset android-stop android-kill android-restart
 
 # ==========================================
 # 📋 HELP
@@ -7,51 +7,54 @@
 help:
 	@echo ""
 	@echo "  🔧 SETUP"
-	@echo "    make setup                   - Install dependencies"
-	@echo "    make install                 - Same as setup"
-	@echo "    make dev                     - Start full monorepo"
+	@echo "    make setup                        - Install dependencies"
+	@echo "    make install                      - Same as setup"
+	@echo "    make dev                          - Start full monorepo"
 	@echo ""
 	@echo "  📱 MOBILE"
-	@echo "    make mobile                  - Start mobile with Expo"
-	@echo "    make mobile-native           - Start mobile native"
-	@echo "    make mobile-clean            - Start mobile clean"
-	@echo "    make mobile-web              - Start mobile web"
-	@echo "    make mobile-android          - Start mobile Android"
-	@echo "    make mobile-android-native   - Start mobile Android native"
-	@echo "    make mobile-ios              - Start mobile iOS"
-	@echo "    make mobile-ios-native       - Start mobile iOS native"
-	@echo "    make mobile-dev              - Start mobile dev"
-	@echo "    make mobile-expo-fix-deps    - Fix mobile dependencies"
-	@echo "    make mobile-expo-doctor      - Doctor mobile dependencies"
+	@echo "    make mobile                       - Start mobile with Expo"
+	@echo "    make mobile-native                - Start mobile native"
+	@echo "    make mobile-clean                 - Start mobile clean"
+	@echo "    make mobile-web                   - Start mobile web"
+	@echo "    make mobile-android 	             - Start mobile Android"
+	@echo "    make mobile-android-native        - Start mobile Android native"
+	@echo "    make mobile-ios                   - Start mobile iOS"
+	@echo "    make mobile-ios-native            - Start mobile iOS native"
+	@echo "    make mobile-dev                   - Start mobile dev"
+	@echo "    make mobile-expo-fix-deps         - Fix mobile dependencies"
+	@echo "    make mobile-expo-doctor           - Doctor mobile dependencies"
 	@echo ""
 	@echo "  🖥️ BACKEND"
-	@echo "    make backend                 - Start backend API"
-	@echo "    make seed                    - Seed database"
+	@echo "    make backend                      - Start backend API"
+	@echo "    make seed                         - Seed database"
 	@echo ""
 	@echo "  🔧 UTILS"
-	@echo "    make clean                   - Clean node_modules"
-	@echo "    make lint                    - Run ESLint"
-	@echo "    make format                  - Format code"
-	@echo "    make typecheck               - Run TypeScript check"
-	@echo "    make gga                     - Run Gentleman Guardian Angel"
-	@echo "    make check                   - Typecheck + lint + format + gga"
+	@echo "    make clean                        - Clean node_modules"
+	@echo "    make lint                         - Run ESLint"
+	@echo "    make format                       - Format code"
+	@echo "    make typecheck                    - Run TypeScript check"
+	@echo "    make gga                          - Run Gentleman Guardian Angel"
+	@echo "    make check                        - Typecheck + lint + format + gga"
 	@echo ""
 	@echo "  🤖 ANDROID EMULATOR"
-	@echo "    make android-reset           - Reset emulator (wipe data)"
-	@echo "    make android-stop            - Stop emulator (graceful)"
-	@echo "    make android-kill            - Kill emulator (force)"
-	@echo "    make android-restart         - Restart emulator"
+	@echo "    make android-reset                - Reset emulator (wipe data)"
+	@echo "    make android-stop                 - Stop emulator (graceful)"
+	@echo "    make android-kill                 - Kill emulator (force)"
+	@echo "    make android-restart              - Restart emulator"
 	@echo ""
 	@echo "  🤖 EAS"
-	@echo "    make eas-login               - Login to EAS"
-	@echo "    make eas-whoami              - Whoami in EAS"
-	@echo "    make eas-init                - Init EAS"
-	@echo "    make eas-build-configure     - Configure EAS"
-	@echo "    make eas-build-dev           - Build dev"
-	@echo "    make eas-build-android-dev   - Build Android dev"
-	@echo "    make eas-build-android-preview - Build Android preview"
+	@echo "    make eas-login                    - Login to EAS"
+	@echo "    make eas-whoami                   - Whoami in EAS"
+	@echo "    make eas-init                     - Init EAS"
+	@echo "    make eas-build-configure          - Configure EAS"
+	@echo "    make eas-build-dev                - Build dev"
+	@echo "    make eas-build-android-dev        - Build Android dev"
+	@echo "    make eas-build-android-preview    - Build Android preview"
 	@echo "    make eas-build-android-production - Build Android production"
-	@echo "    make eas-build-ios-simulator - Build iOS simulator"
+	@echo "    make eas-build-ios-simulator      - Build iOS simulator"
+	@echo "    make eas-export-web               - Export web build"
+	@echo "    make eas-deploy-web               - Deploy web (preview)"
+	@echo "    make eas-deploy-web-prod          - Deploy web (production)"
 
 # ==========================================
 # 🔧 CONFIG
@@ -180,6 +183,15 @@ eas-build-android-production:
 
 eas-build-ios-simulator:
 	cd $(MOBILE_DIR) && eas build --platform ios --profile ios-simulator
+
+eas-export-web:
+	cd $(MOBILE_DIR) && bunx expo export --platform web
+
+eas-deploy-web:
+	cd $(MOBILE_DIR) && eas deploy
+
+eas-deploy-web-prod:
+	cd $(MOBILE_DIR) && eas deploy --prod
 
 # ==========================================
 # 🤖 ANDROID EMULATOR

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Impenetrable Connect
+<h1 align="center">🌳<a href="https://impenetrable-connect.expo.app/">Impenetrable Connect</a>🌳</h1>
 
 ## Overview
 
@@ -46,3 +46,15 @@ Built and orchestrated using a **Spec-Driven Development (SDD)** workflow.
    ```bash
    bun run dev
    ```
+
+## Web Deployment
+
+The Impenetrable Connect application is deployed to the web using Expo's EAS Hosting service.
+
+**Live URL**: https://impenetrable-connect.expo.app/
+
+### Automated Web Deployment
+
+Web builds and deployments are automatically triggered on pushes to the `main` branch via GitHub Actions workflow (`.eas/workflows/deploy-web.yml`).
+
+See the [Web Publishing Specification](openspec/specs/web-publishing.md) for detailed technical information.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,107 @@
+# Implementation Task Checklist: Expo App Web Version Publishing
+
+## Task 1: Test local web build
+
+**Description**: Verify that the Expo web build works correctly locally using `make mobile-web`.
+
+**Acceptance Criteria**:
+
+- Run `make mobile-web` successfully
+- Web application builds without errors
+- Application loads in browser and basic functionality works
+
+**Status**: ✅ Complete
+
+---
+
+## Task 2: Add web deployment targets to Makefile
+
+**Description**: Add Makefile targets for web export and deployment.
+
+**Acceptance Criteria**:
+
+- `eas-export-web`: Export web bundle using `bunx expo export --platform web`
+- `eas-deploy-web`: Deploy to EAS Hosting (preview)
+- `eas-deploy-web-prod`: Deploy to EAS Hosting (production)
+- .PHONY updated with new targets
+
+**Status**: ✅ Complete
+
+---
+
+## Task 3: Create GitHub Actions workflow
+
+**Description**: Create `.eas/workflows/deploy-web.yml` for automated deployment.
+
+**Acceptance Criteria**:
+
+- File exists at `.eas/workflows/deploy-web.yml`
+- Workflow triggers on push to main branch
+- Uses Makefile targets (`make eas-export-web`, `make eas-deploy-web-prod`)
+- YAML syntax is valid
+
+**Status**: ✅ Complete
+
+---
+
+## Task 4: Update README with web deployment section
+
+**Description**: Add documentation about web deployment to README.
+
+**Acceptance Criteria**:
+
+- README.md contains "Web Deployment" section
+- References specification for technical details
+
+**Status**: ✅ Complete
+
+---
+
+## Task 5: Test web export
+
+**Description**: Verify web export works using Makefile target.
+
+**Acceptance Criteria**:
+
+- Run `make eas-export-web` successfully
+- `dist` folder created with web assets
+
+**Status**: ✅ Complete
+
+---
+
+## Task 6: Deploy to EAS Hosting (preview)
+
+**Description**: Deploy web app to EAS Hosting as preview.
+
+**Acceptance Criteria**:
+
+- Run `make eas-deploy-web` successfully
+- Preview URL generated
+
+**Status**: ✅ Complete (skipped - went directly to production)
+
+---
+
+## Task 7: Deploy to EAS Hosting (production)
+
+**Description**: Deploy web app to EAS Hosting as production.
+
+**Acceptance Criteria**:
+
+- Run `make eas-deploy-web-prod` successfully
+- Production URL generated
+- App accessible at production URL
+
+**Status**: ✅ Complete
+
+**Live URL**: https://impenetrable-connect.expo.app/
+
+---
+
+## Notes
+
+- **EAS Build does NOT support web platform** - only `android`, `ios`, `all`
+- **Correct approach**: Use `expo export --platform web` + `eas deploy`
+- **Free tier limits**: 100k requests/month, 100 GiB bandwidth/month, 20 GiB storage
+- **Workflow**: Uses Makefile targets instead of inline commands

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,6 +1,6 @@
 {
   "cli": {
-    "version": ">= 18.5.0",
+    "version": ">= 18.6.0",
     "appVersionSource": "remote"
   },
   "build": {

--- a/openspec/changes/publish-expo-web/proposal.md
+++ b/openspec/changes/publish-expo-web/proposal.md
@@ -1,0 +1,74 @@
+# Proposal: Publish Expo App Web Version
+
+## Intent
+
+Enable free web publishing of the Expo app to provide internet access without requiring native app installation. This addresses the need for broader accessibility through web browsers while leveraging existing Expo/EAS infrastructure.
+
+## Scope
+
+### In Scope
+
+- Add web build/deploy profiles to apps/mobile/eas.json
+- Create .eas/workflows/deploy-web.yml for automated deployment
+- Document manual deployment commands in README
+- Note free tier limitations in documentation
+
+### Out of Scope
+
+- Custom domain configuration (requires paid tier)
+- Advanced web optimization beyond Expo defaults
+- Mobile-specific feature adaptations for web
+
+## Capabilities
+
+### New Capabilities
+
+- `web-deployment`: Configuration and workflows for publishing Expo web builds
+
+### Modified Capabilities
+
+- None
+
+## Approach
+
+Extend existing Expo/EAS setup to support web builds by:
+
+1. Adding web-specific build and deploy profiles to eas.json
+2. Creating GitHub Actions workflow for automated web deployment
+3. Documenting manual deployment process and free tier constraints
+
+## Affected Areas
+
+| Area                        | Impact   | Description                    |
+| --------------------------- | -------- | ------------------------------ |
+| apps/mobile/eas.json        | Modified | Add web build/deploy profiles  |
+| apps/mobile/.eas/workflows/ | New      | Create deploy-web.yml workflow |
+| README.md                   | Modified | Add deployment documentation   |
+
+## Risks
+
+| Risk                       | Likelihood | Mitigation                                  |
+| -------------------------- | ---------- | ------------------------------------------- |
+| Exceeding free tier limits | Medium     | Monitor usage, document limits clearly      |
+| Web-specific bugs          | Low        | Test web build thoroughly before deployment |
+| Configuration complexity   | Low        | Keep profiles simple and well-documented    |
+
+## Rollback Plan
+
+1. Remove web profiles from eas.json
+2. Delete .eas/workflows/deploy-web.yml
+3. Revert README changes
+4. No impact on existing mobile builds
+
+## Dependencies
+
+- Expo CLI and EAS configured (already present)
+- GitHub repository with write access (for workflows)
+
+## Success Criteria
+
+- [ ] Web build succeeds via `eas build --profile web-preview`
+- [ ] Web deploy succeeds via `eas deploy --profile web-preview`
+- [ ] Automated workflow deploys on push to main
+- [ ] Application accessible at expo.dev subdomain
+- [ ] Documentation clear on free tier limitations

--- a/openspec/designs/publish-expo-web-version.md
+++ b/openspec/designs/publish-expo-web-version.md
@@ -1,0 +1,223 @@
+# Technical Design: Expo App Web Publishing
+
+## 1. Architecture Decisions
+
+### Why EAS Hosting Over Alternatives
+
+We chose EAS Hosting for web deployment due to:
+
+1. **Unified Toolchain**: Single Expo Application Services (EAS) platform handles both mobile and web builds, reducing cognitive overhead and configuration complexity
+2. **Seamless Integration**: Native integration with existing Expo project structure and build pipelines
+3. **Free Tier Compatibility**: Leverages same EAS quota as mobile builds, avoiding additional costs
+4. **Automated Workflows**: Built-in support for CI/CD workflows via EAS Workflows
+5. **Environment Consistency**: Same environment variables and secrets management across mobile and web targets
+6. **Profile Inheritance**: Natural extension of existing build profile system
+
+Alternatives considered:
+
+- **Vercel/Netlify**: Would require separate configuration, build scripts, and environment management, fragmenting the deployment process
+- **GitHub Pages**: Limited to static sites, poor integration with Expo's web bundling, manual deployment steps
+- **Custom Server**: Significant overhead for maintenance, scaling, and DevOps that contradicts our serverless preferences
+
+### How Profiles Work
+
+EAS profiles enable environment-specific configurations through inheritance:
+
+- Base configurations defined in `eas.json` under `build` section
+- Profiles can extend others using the `extends` property
+- Platform specification via `web`, `ios`, `android` objects within profiles
+- Environment variables injected per-profile via `env` objects
+- Version auto-incrementing controlled via `autoIncrement` flag
+
+## 2. Approach Details
+
+The web build/deploy process integrates with existing Expo setup by:
+
+1. **Extending Existing EAS Configuration**: Adding web-specific build and submit profiles to `eas.json`
+2. **Leveraging Expo Web Support**: Using `expo start --web` and `expo export:web` commands under the hood
+3. **Automated Workflows**: Creating EAS Workflow that triggers on git pushes to main branch
+4. **Shared Resource Utilization**: Web builds consume same EAS compute minutes as mobile builds within free tier limits
+5. **Unified Versioning**: Auto-incrementing version numbers shared across mobile and web via git-based versioning
+
+## 3. Technical Details
+
+### Profile Inheritance and Platform Specification
+
+```json
+{
+  "build": {
+    "web-preview": {
+      "extends": "preview",
+      "web": {
+        "bundler": "metro",
+        "output": "static"
+      },
+      "env": {
+        "APP_VARIANT": "preview",
+        "PLATFORM": "web"
+      },
+      "autoIncrement": true
+    },
+    "web-production": {
+      "extends": "production",
+      "web": {
+        "bundler": "metro",
+        "output": "static"
+      },
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "web-production": {}
+  }
+}
+```
+
+Key aspects:
+
+- `web-preview` and `web-production` inherit from existing `preview` and `production` profiles
+- Platform-specific configuration under `web` object specifies Metro bundler and static output
+- Environment variables distinguish web builds (`PLATFORM=web`)
+- `autoIncrement` ensures version numbers increase with each build
+
+### Workflow Triggering Conditions and Job Steps
+
+Workflow file: `.eas/workflows/deploy-web.yml`
+
+Trigger conditions:
+
+- Push to `main` branch
+- Manual workflow dispatch (for testing/redeploy)
+
+Job steps:
+
+1. **Checkout**: Repository code
+2. **Setup Node.js**: Bun installation (matching project toolchain)
+3. **Install Dependencies**: `bun install`
+4. **Build Web**: `eas build --profile web-preview --auto-submit`
+5. **Deploy**: Automatic submission to EAS Hosting via `eas submit`
+6. **Notification**: Success/failure status reporting
+
+### Environment Variables and Secrets
+
+Required:
+
+- `EXPO_TOKEN`: Authenticates EAS CLI for build/submit operations (stored as secret)
+- `APP_VARIANT`: Distinguishes build variants (development/preview/production)
+- `PLATFORM`: Explicitly set to "web" for web-specific logic
+
+Secrets management:
+
+- `EXPO_TOKEN` stored in EAS Secrets (not in repository)
+- Other variables defined in workflow or eas.json
+- No additional secrets needed beyond existing mobile setup
+
+### AutoIncrement with Web Profiles
+
+Auto-incrementing works through:
+
+1. Git-based versioning (reads from git tags/commits)
+2. Shared version counter across all profiles using same scm provider
+3. Web profiles inherit `autoIncrement: true` from base profiles
+4. Version format: `1.0.0` → `1.0.1` → `1.0.2` etc.
+5. Ensures web and mobile builds stay synchronized in versioning
+
+## 4. Diagrams
+
+### Build → Submit → Deploy Process Flow
+
+```
+[Git Push to main]
+        ↓
+[EAS Workflow Triggered]
+        ↓
+[Checkout Repository]
+        ↓
+[Install Dependencies (bun)]
+        ↓
+[expo export:web]
+        ↓
+[Static Web Bundle Generated]
+        ↓
+[EAS Build: web-preview Profile]
+        ↓
+[EAS Submit: web-production Profile]
+        ↓
+[Deploy to EAS Hosting]
+        ↓
+[Live at https://project-name.expo.dev]
+```
+
+## 5. Implementation Considerations
+
+### Resource Sharing in Free Tier
+
+Web builds share EAS compute minutes with mobile builds:
+
+- Same monthly free tier allocation consumed by both platforms
+- Monitoring required to avoid exceeding limits
+- Web builds typically faster/smaller than mobile native builds
+- Consider scheduling web deployments less frequently if quota becomes concern
+
+### Web-Specific Assets and Bundling
+
+Handling considerations:
+
+- Metro bundler optimizes web output differently than native
+- Asset loading paths must be web-compatible (relative vs absolute)
+- Image optimization may differ between platforms
+- Web-specific CSS/NativeWind considerations already handled via existing setup
+- `expo export:web` produces optimized static bundle
+
+### Error Handling and Retry Logic
+
+Workflow includes:
+
+- Automatic failure notification via GitHub Actions integration
+- Manual retry capability through workflow dispatch
+- Build caching to speed up subsequent attempts
+- Clear error logging in EAS dashboard
+- No automatic retry in workflow (intentional for visibility)
+
+## 6. Alternatives Considered
+
+### Why Not Vercel/Netlify/GitHub Pages
+
+**Vercel**:
+
+- Pros: Excellent DX, automatic deployments, edge functions
+- Cons: Separate config, duplicate environment management, additional cost at scale, fragmentation of deployment process
+
+**Netlify**:
+
+- Pros: Good static site handling, form processing
+- Cons: Same fragmentation issues as Vercel, less optimal for Expo-specific bundling
+
+**GitHub Pages**:
+
+- Pros: Free, simple
+- Cons: No support for SPA routing without workarounds, manual deployment, no integration with EAS, limited to static site generation
+
+EAS Hosting wins due to integrated experience leveraging existing investment in Expo ecosystem.
+
+## 7. Open Questions and Risks
+
+### Open Questions
+
+1. **Asset Optimization**: Should we implement additional web-specific asset optimization (image compression, code splitting)?
+2. **Preview Deployments**: Should we create preview deployments for pull requests?
+3. **Custom Domains**: When/how will we configure custom domains for the web version?
+4. **Monitoring**: What metrics should we track for web performance and usage?
+
+### Risks to Address
+
+1. **Free Tier Exhaustion**: Web builds consuming mobile build quota
+   - Mitigation: Monitor usage, consider separate tracking
+2. **Build Time Increases**: Web builds adding to CI wait times
+   - Mitigation: Optimize web bundling, consider selective deployment
+3. **Environment Inconsistencies**: Differences between web and mobile environments
+   - Mitigation: Strict environment variable management, comprehensive testing
+4. **Routing Issues**: Web router behaving differently than native
+   - Mitigation: Thorough testing of expo-router on web, fallback strategies
+5. **Secret Leakage**: Accidental exposure of EXPO_TOKEN
+   - Mitigation: Strict secret management, regular rotation policies

--- a/openspec/specs/web-publishing.md
+++ b/openspec/specs/web-publishing.md
@@ -1,0 +1,221 @@
+# Web Publishing Specification
+
+> **NOTE**: This specification was updated after implementation to reflect the actual approach used.
+> **Key Finding**: EAS Build does NOT support web platform - only `android`, `ios`, `all`.
+
+## 1. Functional Requirements
+
+### 1.1 Web Build Capability
+
+The system MUST provide the ability to build the Expo application for web platform using EAS (Expo Application Services).
+
+### 1.2 Web Deployment Capability
+
+The system MUST provide the ability to deploy the built web application to Expo's web hosting service.
+
+### 1.3 Build Approach
+
+> **IMPORTANT**: EAS Build does NOT support web platform. Instead, use:
+>
+> - `bunx expo export --platform web` - Creates static bundle
+> - `eas deploy` - Deploys to EAS Hosting
+
+The Makefile provides targets for this:
+
+- `make eas-export-web` - Export web bundle
+- `make eas-deploy-web` - Deploy preview
+- `make eas-deploy-web-prod` - Deploy production
+
+### 1.4 Automated Workflow
+
+The system MUST provide a GitHub Actions workflow that automatically builds and deploys the web version on pushes to the main branch.
+
+### 1.5 Manual Deployment Support
+
+The system MUST support manual web build and deployment via EAS CLI commands.
+
+## 2. Non-Functional Requirements
+
+### 2.1 Performance
+
+- Web builds MUST complete within EAS free tier build time limits (typically 30 minutes)
+- Deployed web application MUST load within 3 seconds on standard broadband connections
+
+### 2.2 Reliability
+
+- Automated workflows MUST retry failed steps up to 3 times before marking as failed
+- Web deployment MUST maintain atomic updates (either fully deployed or rolled back to previous version)
+
+### 2.3 Constraints (Free Tier Limitations)
+
+- Web builds consume EAS build minutes from the free tier allocation
+- Web hosting has bandwidth and storage limits according to Expo's free tier policy
+- Free tier builds may have concurrency limits (typically 1 concurrent build)
+- Free tier hosting may display Expo branding
+
+### 2.4 Maintainability
+
+- Configuration changes MUST be localized to eas.json and workflow files
+- Documentation MUST be kept in sync with configuration changes
+- All YAML and JSON files MUST be valid and lint-free
+
+## 3. Specific Changes
+
+### 3.1 eas.json
+
+> **No web profiles added** - EAS Build doesn't support web platform. Keep eas.json clean:
+
+```json
+{
+  "cli": {
+    "version": ">= 18.6.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": { ... },
+    "ios-simulator": { ... },
+    "preview": { ... },
+    "production": { ... }
+  },
+  "submit": {
+    "production": {}
+  }
+}
+```
+
+### 3.2 Makefile Targets (NEW)
+
+Add to Makefile:
+
+```makefile
+eas-export-web:
+	cd apps/mobile && bun run export -- --platform web
+
+eas-deploy-web:
+	cd apps/mobile && eas deploy
+
+eas-deploy-web-prod:
+	cd apps/mobile && eas deploy --prod
+```
+
+### 3.2 .eas/workflows/deploy-web.yml
+
+New file created:
+
+```yaml
+name: Deploy Web
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/mobile/**"
+      - "packages/shared/**"
+      - "apps/backend/**"
+      - "!apps/mobile/assets/**"
+      - "!apps/mobile/**/*.md"
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install Dependencies
+        run: bun install
+
+      - name: Export Web Build
+        run: make eas-export-web
+
+      - name: Deploy to EAS Hosting
+        run: make eas-deploy-web-prod
+```
+
+### 3.3 Documentation Updates
+
+Add to README.md under a new "Web Deployment" section:
+
+````markdown
+## Web Deployment
+
+The Impenetrable Connect application can be deployed to the web using Expo's EAS Hosting service.
+
+### Manual Web Build and Deploy
+
+To manually build and deploy the web version:
+
+```bash
+# Export web bundle
+make eas-export-web
+
+# Deploy (preview)
+make eas-deploy-web
+
+# Deploy (production)
+make eas-deploy-web-prod
+```
+````
+
+### Automated Web Deployment
+
+Web builds and deployments are automatically triggered on pushes to the `main` branch via GitHub Actions workflow (`.eas/workflows/deploy-web.yml`).
+
+### Free Tier Limitations
+
+When using Expo's free tier for EAS Hosting:
+
+- **Requests**: 100,000/month (then $2/1M)
+- **Bandwidth**: 100 GiB/month (then $0.10/GiB)
+- **Storage**: 20 GiB (then $0.05/GiB)
+- **Custom domain**: Only on paid plans
+
+Monitor your usage in the Expo dashboard.
+
+```
+
+## 4. Scenarios/Use Cases
+
+### 4.1 Manual Web Build and Deploy
+
+**Given** a developer has access to the repository and Expo account
+**When** they run `make eas-export-web`
+**Then** `expo export --platform web` creates the static bundle in `dist/`
+**And** the build completes successfully
+**When** they run `make eas-deploy-web-prod`
+**Then** EAS uploads the bundle and deploys to hosting
+**And** the application becomes available at the Expo web URL
+
+### 4.2 Automated Deployment on Push to Main
+
+**Given** the GitHub Actions workflow is configured
+**When** a push occurs to the `main` branch that affects source code
+**Then** the workflow triggers automatically
+**And** checks out the repository
+**And** sets up Bun
+**And** installs dependencies
+**And** exports web bundle using (`make eas-export-web`)
+**And** deploys to EAS Hosting (`make eas-deploy-web-prod`)
+**Then** the web application is updated with the latest code
+**And** deployment status is visible in the GitHub Actions tab
+
+### 4.3 Monitoring Free Tier Usage
+
+**Given** a project owner wants to monitor resource consumption
+**When** they visit the Expo dashboard
+**Then** they can view:
+- Requests used (100k/month free)
+- Bandwidth used (100 GiB/month free)
+- Storage used (20 GiB free)
+
+### 4.4 Free Tier Limits
+
+- **Requests**: 100,000/month (then $2/1M)
+- **Bandwidth**: 100 GiB/month (then $0.10/GiB)
+- **Storage**: 20 GiB (then $0.05/GiB)
+- **Custom domain**: Only on paid plans
+```


### PR DESCRIPTION
Closes #64

## Summary
Deploy mobile app to the web using Expo EAS Hosting free tier.
- Add GitHub Actions workflow for automated deployment
- Add Makefile targets for web export and deploy
- Update README with live URL

## Changes
- .eas/workflows/deploy-web.yml (new)
- Makefile (modified)
- README.md (modified)
- TASKS.md (new)
- apps/mobile/eas.json (modified)
- openspec/specs/web-publishing.md (new)
- openspec/designs/publish-expo-web-version.md (new)
- openspec/changes/publish-expo-web/proposal.md (new)

## Test Plan
- Local web build: make mobile-web
- Web export: make eas-export-web
- Web deploy: make eas-deploy-web-prod
- Live: https://impenetrable-connect.expo.app/