### PR TITLE
ci: add GitHub Actions workflow for web build + EAS deploy

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -22,10 +22,12 @@ jobs:
           bun-version: latest
 
       - name: Install Dependencies
-        run: bun install
+        run: make setup
 
       - name: Export Web Build
         run: make eas-export-web
 
       - name: Deploy to EAS Hosting
         run: make eas-deploy-web-prod
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}


### PR DESCRIPTION
## Summary

- Add  for web build using GitHub Actions
- Delete old  (replaced by GitHub Actions)
- Use Makefile targets (bun install
bun install v1.3.3 (274e01c7)

Checked 895 installs across 890 packages (no changes) [7.26s], cd apps/mobile && bunx expo export --platform web
env: load .env.local
env: export EXPO_PUBLIC_API_URL EXPO_PUBLIC_USE_MOCKS
Using src/app as the root directory for Expo Router.
Expo Autolinking module resolution enabled
Starting Metro Bundler

Web node_modules/.bun/expo-router@55.0.11+2266505dcde30d9c/node_modules/expo-router/entry.js ░░░░░░░░░░░░░░░░  0.0% (0/1)
Web Bundled 1213ms node_modules/.bun/expo-router@55.0.11+2266505dcde30d9c/node_modules/expo-router/entry.js (1081 modules)

› Assets (20):
../../node_modules/.bun/@expo+vector-icons@15.1.1+3c0635973ffbd659/node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/MaterialCommunityIcons.6e435534bd35da5fef04168860a9b8fa.ttf (1.3MB)
../../node_modules/.bun/@react-navigation+elements@2.9.14+64928a0df13996a2/node_modules/@react-navigation/elements/lib/module/assets/back-icon-mask.0a328cd9c1afd0afe8e3b1ec5165b1b4.png (653B)
../../node_modules/.bun/@react-navigation+elements@2.9.14+64928a0df13996a2/node_modules/@react-navigation/elements/lib/module/assets/back-icon.35ba0eaec5a4f5ed12ca16fabeae451d.png (207B)
../../node_modules/.bun/@react-navigation+elements@2.9.14+64928a0df13996a2/node_modules/@react-navigation/elements/lib/module/assets/clear-icon.c94f6478e7ae0cdd9f15de1fcb9e5e55.png (4 variations | 425B)
../../node_modules/.bun/@react-navigation+elements@2.9.14+64928a0df13996a2/node_modules/@react-navigation/elements/lib/module/assets/close-icon.808e1b1b9b53114ec2838071a7e6daa7.png (4 variations | 235B)
../../node_modules/.bun/@react-navigation+elements@2.9.14+64928a0df13996a2/node_modules/@react-navigation/elements/lib/module/assets/search-icon.286d67d3f74808a60a78d3ebf1a5fb57.png (928B)
../../node_modules/.bun/expo-router@55.0.11+2266505dcde30d9c/node_modules/expo-router/assets/arrow_down.017bc6ba3fc25503e5eb5e53826d48a8.png (9.5KB)
../../node_modules/.bun/expo-router@55.0.11+2266505dcde30d9c/node_modules/expo-router/assets/error.d1ea1496f9057eb392d5bbf3732a61b7.png (469B)
../../node_modules/.bun/expo-router@55.0.11+2266505dcde30d9c/node_modules/expo-router/assets/file.19eeb73b9593a38f8e9f418337fc7d10.png (138B)
../../node_modules/.bun/expo-router@55.0.11+2266505dcde30d9c/node_modules/expo-router/assets/forward.d8b800c443b8972542883e0b9de2bdc6.png (188B)
../../node_modules/.bun/expo-router@55.0.11+2266505dcde30d9c/node_modules/expo-router/assets/pkg.ab19f4cbc543357183a20571f68380a3.png (364B)
../../node_modules/.bun/expo-router@55.0.11+2266505dcde30d9c/node_modules/expo-router/assets/sitemap.412dd9275b6b48ad28f5e3d81bb1f626.png (465B)
../../node_modules/.bun/expo-router@55.0.11+2266505dcde30d9c/node_modules/expo-router/assets/unmatched.20e71bdf79e3a97bf55fd9e164041578.png (4.8KB)
assets/jaguar-hero.c8488ea899590c042781af10cee43438.png (492KB)

› web bundles (2):
_expo/static/css/web-e5fbe0f0e7442bc7646ac829d54be879.css (15KB)
_expo/static/js/web/entry-1db62a4b35db89e2eb41efc7de0ead4c.js (1.6MB)

› Files (3):
favicon.ico (15KB)
index.html (1.4KB)
metadata.json (49B)

Exported: dist, cd apps/mobile && eas deploy --prod
> Project export: static
- Preparing project
- Creating deployment
✔ Created deployment
- Promoting deployment to production
✔ Promoted deployment to production

🎉 Your deployment is ready

Dashboard       https://expo.dev/projects/430a65eb-19e4-4158-9822-475364cb6664/hosting/deployments
Deployment URL  https://impenetrable-connect--xxf1ryqk8i.expo.app
Production URL  https://impenetrable-connect.expo.app)

## Changes

| File | Change |
|------|--------|
|  | New - GitHub Actions workflow |
|  | Deleted - replaced by GitHub Actions |

## Test Plan

- [x] Workflow will trigger on push to main with path changes in , , 
- [x] Requires  secret configured in GitHub repo settings

## Checklist

- [x] Linked approved issue: Closes #66
- [ ] Added  label
- [x] Conventional commit format
- [x] No  trailers