### PR TITLE
fix: use --package flag for bunx eas deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ eas-deploy-web:
 	cd $(MOBILE_DIR) && eas deploy
 
 eas-deploy-web-prod:
-	cd $(MOBILE_DIR) && bunx eas deploy --prod
+	cd $(MOBILE_DIR) && bunx --package eas-cli eas deploy --prod
 	
 # ==========================================
 # 🤖 ANDROID EMULATOR


### PR DESCRIPTION
## Summary

- Use No "dist/" folder found. Export your app with "npx expo export --platform web" in Makefile to fix "could not determine executable" error

## Changes

| File | Change |
|------|--------|
|  | Use  flag for bunx |

## Test Plan

- [x] Run cd apps/mobile && bunx --package eas-cli eas deploy --prod
> Project export: static - exported 1 hour ago
- Preparing project
- Creating deployment
✔ Created deployment
- Promoting deployment to production
✔ Promoted deployment to production

🎉 Your deployment is ready

Dashboard       https://expo.dev/projects/430a65eb-19e4-4158-9822-475364cb6664/hosting/deployments
Deployment URL  https://impenetrable-connect--moelcg9xiq.expo.app
Production URL  https://impenetrable-connect.expo.app locally - works without error

## Checklist

- [x] Linked approved issue: Closes #70
- [x] Added `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers