### PR TITLE
feat: move role selector text to i18n

### DIFF
--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -10,6 +10,7 @@ import {
   type DemoUser,
 } from "../mocks/users";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { useTranslations } from "../hooks/useI18n";
 
 // Role colors from design system - mapped for icons and backgrounds
 const ROLE_COLORS = {
@@ -63,11 +64,7 @@ const ROLE_CONFIG = {
   },
 } as const;
 
-const ROLE_DESCRIPTIONS = {
-  TOURIST: "Explora servicios turísticos del Chaco",
-  ENTREPRENEUR: "Gestiona tus servicios y reservas",
-  ADMIN: "Administra proyectos y emprendedores",
-} as const;
+// Role metadata moved to i18n
 
 export default function RoleSelectorScreen() {
   const { setUserRole } = useAuthStore();
@@ -121,23 +118,29 @@ export default function RoleSelectorScreen() {
   };
 
   const demoUsersByRole = [
-    { role: "TOURIST" as const, label: "Turistas", users: DEMO_TOURIST_USERS },
-    { role: "ENTREPRENEUR" as const, label: "Emprendedores", users: DEMO_ENTREPRENEUR_USERS },
-    { role: "ADMIN" as const, label: "Administradores", users: DEMO_ADMIN_USERS },
-  ];
+    { role: "TOURIST" as const, users: DEMO_TOURIST_USERS },
+    { role: "ENTREPRENEUR" as const, users: DEMO_ENTREPRENEUR_USERS },
+    { role: "ADMIN" as const, users: DEMO_ADMIN_USERS },
+  ] as const;
+
+  const { t } = useTranslations();
 
   return (
     <Screen>
       <ScreenContent>
         <ScrollView showsVerticalScrollIndicator={false}>
-          <Text className="text-3xl font-display font-bold text-on-surface mb-2">Welcome</Text>
+          <Text className="text-3xl font-display font-bold text-on-surface mb-2">
+            {t("role_selector.welcome")}
+          </Text>
           <Text className="text-base text-on-surface opacity-60 mb-8">
-            Select your demo user to get started
+            {t("role_selector.subtitle")}
           </Text>
 
           {demoUsersByRole.map((group) => {
             const config = ROLE_CONFIG[group.role];
-            const description = ROLE_DESCRIPTIONS[group.role];
+            const roleKey = group.role.toLowerCase();
+            const label = t(`role_selector.roles.${roleKey}.label`);
+            const description = t(`role_selector.roles.${roleKey}.description`);
             return (
               <View key={group.role} className="mb-6">
                 {/* Role Header - Prominent styling */}
@@ -154,9 +157,7 @@ export default function RoleSelectorScreen() {
                     />
                   </View>
                   <View className="flex-1">
-                    <Text className="text-lg font-display font-bold text-on-surface">
-                      {group.label}
-                    </Text>
+                    <Text className="text-lg font-display font-bold text-on-surface">{label}</Text>
                     <Text className="text-xs text-on-surface opacity-60">{description}</Text>
                   </View>
                 </View>
@@ -174,11 +175,11 @@ export default function RoleSelectorScreen() {
                         color="tertiary-container"
                       />
                       <Text className={`text-base font-medium ${config.textClass}`}>
-                        Crear mi identidad
+                        {t("role_selector.create_identity")}
                       </Text>
                     </View>
                     <Text className="text-xs text-on-surface opacity-50 mt-1 ml-7">
-                      Registrarme como turista
+                      {t("role_selector.register_as_tourist")}
                     </Text>
                   </TouchableOpacity>
                 )}

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -141,5 +141,25 @@
   },
   "common": {
     "cancel": "Cancel"
+  },
+  "role_selector": {
+    "welcome": "Welcome",
+    "subtitle": "Select your demo user to get started",
+    "create_identity": "Create my identity",
+    "register_as_tourist": "Register as a tourist",
+    "roles": {
+      "tourist": {
+        "label": "Tourists",
+        "description": "Explore tourist services in the Chaco"
+      },
+      "entrepreneur": {
+        "label": "Entrepreneurs",
+        "description": "Manage your services and reservations"
+      },
+      "admin": {
+        "label": "Administrators",
+        "description": "Manage projects and entrepreneurs"
+      }
+    }
   }
 }

--- a/apps/mobile/src/i18n/locales/es.json
+++ b/apps/mobile/src/i18n/locales/es.json
@@ -141,5 +141,25 @@
   },
   "common": {
     "cancel": "Cancelar"
+  },
+  "role_selector": {
+    "welcome": "Bienvenido",
+    "subtitle": "Seleccioná tu usuario demo para comenzar",
+    "create_identity": "Crear mi identidad",
+    "register_as_tourist": "Registrarme como turista",
+    "roles": {
+      "tourist": {
+        "label": "Turistas",
+        "description": "Explorá servicios turísticos del Chaco"
+      },
+      "entrepreneur": {
+        "label": "Emprendedores",
+        "description": "Gestioná tus servicios y reservas"
+      },
+      "admin": {
+        "label": "Administradores",
+        "description": "Administrá proyectos y emprendedores"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Use  hook in index.tsx
- Add role_selector translations to en.json and es.json
- Remove hardcoded ROLE_DESCRIPTIONS constant
- Replace hardcoded labels with i18n keys

## Changes

| File | Change |
|------|--------|
|  | Use useTranslations hook, remove hardcoded text |
|  | Add role_selector translations |
|  | Add role_selector translations |

## Test Plan

- [x] TypeScript compiles without errors
- [x] Lint passes
- [x] Code review passed

## Checklist

- [x] Linked approved issue: Closes #72
- [ ] Added `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers