### PR TITLE
fix(mobile): pin eas-cli version to 18.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ eas-deploy-web:
 	cd $(MOBILE_DIR) && eas deploy
 
 eas-deploy-web-prod:
-	cd $(MOBILE_DIR) && bunx --package eas-cli eas deploy --prod
+	cd $(MOBILE_DIR) && bunx --package eas-cli@18.6.0 eas deploy --prod
 	
 # ==========================================
 # 🤖 ANDROID EMULATOR


### PR DESCRIPTION
Closes #84

### Summary
Fixed the version mismatch in GH Actions by explicitly pinning eas-cli to 18.6.0 in the Makefile.