### PR TITLE
feat(agent): configure skills registry and technical standards

### DIFF
--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -40,6 +40,11 @@
 - **Branching**: Always create a descriptive feature branch (e.g., `issue-#/short-description`).
 - **Pull Requests**: Every change must be submitted via a PR linked to the issue.
 - **Commits**: Use conventional commits only. No AI attribution in commit messages.
+- **Post-Merge Cleanup**: When the user says "mergeado" (merged), the agent MUST:
+    1. Confirm the PR and its linked issue are closed (`gh pr view` / `gh issue view`).
+    2. Switch to `main` branch.
+    3. Pull the latest remote changes (`git pull origin main`).
+    4. Delete the local feature branch (`git branch -d branch-name`).
 
 ## User Skills
 

--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -41,10 +41,10 @@
 - **Pull Requests**: Every change must be submitted via a PR linked to the issue.
 - **Commits**: Use conventional commits only. No AI attribution in commit messages.
 - **Post-Merge Cleanup**: When the user says "mergeado" (merged), the agent MUST:
-    1. Confirm the PR and its linked issue are closed (`gh pr view` / `gh issue view`).
-    2. Switch to `main` branch.
-    3. Pull the latest remote changes (`git pull origin main`).
-    4. Delete the local feature branch (`git branch -d branch-name`).
+  1. Confirm the PR and its linked issue are closed (`gh pr view` / `gh issue view`).
+  2. Switch to `main` branch.
+  3. Pull the latest remote changes (`git pull origin main`).
+  4. Delete the local feature branch (`git branch -d branch-name`).
 
 ## User Skills
 

--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -1,76 +1,67 @@
-# Skill Registry
+# Skill Registry - rewilding-connect
 
-**Delegator use only.** Any agent that launches sub-agents reads this registry to resolve compact rules, then injects them directly into sub-agent prompts. Sub-agents do NOT read this registry or individual SKILL.md files.
+## Project Standards
 
-## Project-Level Skills
+### TypeScript
 
-| Trigger                                                                    | Skill                        | Path                                                |
-| -------------------------------------------------------------------------- | ---------------------------- | --------------------------------------------------- |
-| When writing Hono API endpoints, middleware or backend routes              | `hono`                       | `.agent/skills/hono/SKILL.md`                       |
-| When creating/modifying database schemas, queries or database transactions | `drizzle-orm`                | `.agent/skills/drizzle-orm/SKILL.md`                |
-| When designing or generating UIs, screens, or visual layouts               | `frontend-design`            | `.agent/skills/frontend-design/SKILL.md`            |
-| When building deep React Native features or tuning performance             | `vercel-react-native-skills` | `.agent/skills/vercel-react-native-skills/SKILL.md` |
-| When styling mobile components or configuring UI elements                  | `expo-tailwind-setup`        | `.agent/skills/expo-tailwind-setup/SKILL.md`        |
-| When configuring GitHub actions for deployment or EAS builds               | `expo-deployment`            | `.agent/skills/expo-deployment/SKILL.md`            |
-| When adding native dependencies that require rebuilds outside Expo Go      | `expo-dev-client`            | `.agent/skills/expo-dev-client/SKILL.md`            |
-| When auditing or finalizing a UI view                                      | `web-design-guidelines`      | `.agent/skills/web-design-guidelines/SKILL.md`      |
+- **Strict Typing**: No `any` types. Use proper types or `unknown` with narrowing.
+- **Immutability**: Use `const` over `let` wherever possible.
+- **Contract Definition**: Prefer `interface` over `type` for objects and service definitions.
 
-## Compact Rules
+### React & React Native
 
-Pre-digested rules per skill. Delegators copy matching blocks into sub-agent prompts as `## Project Standards (auto-resolved)`.
+- **Functional Components**: Use functional components with hooks only.
+- **Imports**: No legacy `import * as React`. Use named imports (e.g., `import { useState }`).
+- **Accessibility**: All images must have descriptive `alt` text (web) or `accessibilityLabel` (native).
+- **Performance**: Use dynamic components with `FlashList` for long lists and avoid heavy JS-side animations.
 
-### hono
+### Styling (NativeWind v4 + Tailwind v3)
 
-- Return JSON responses strictly matching API spec with consistent Error shapes
-- Rely on `zValidator` to auto-inject typed `c.req.valid('json')`
-- Ensure routes use Hono RPC client compatibility for the mobile app
+- **Utilities First**: Use NativeWind CSS utilities only. No inline `style={...}`.
+- **Design Tokens**: Never hardcode colors/spacing. Use the established design system tokens.
+- **Native Context**: Be aware of NativeWind v4 limitations vs v5/v6.
 
-### drizzle-orm
+### Architecture & Monorepo
 
-- Always use the precise PostgreSQL data types
-- Ensure strict type safety by exporting `typeof` for insertion and selection schemas
-- Use explicit foreign keys
-- Write queries utilizing the Drizzle syntax without raw SQL strings where possible
+- **Single Source of Truth**: Shared types and validators must live in `@repo/shared`.
+- **Vertical Slicing**: Keep backend routes logic in services, not in the route handler.
+- **Error Handling**: Use Zod for all input validations on both sides of the bridge.
 
-### frontend-design
+### Testing
 
-- REJECT generic Bootstrap/Tailwind standard colors (e.g., pure blue, red). Use tailored, harmonious HSL palettes
-- Apply subtle glassmorphism and modern gradient overlays
-- Emphasize rich animations to give life to dynamic data
-- MUST create UIs that feel "Premium" and highly polished
+- **TDD First**: Follow the strict TDD protocol when implementing new features.
+- **Coverage**: Verify critical paths with `@testing-library/react-native`.
 
-### vercel-react-native-skills
+### Git & Workflow
 
-- Use `@shopify/flash-list` INSTEAD of FlatList/ScrollView for mapped items
-- Always prefer `Pressable` over `TouchableOpacity`
-- Avoid deeply nesting Views; keep DOM shallow
-- Use Reanimated for complex GPU-bound animations
+- **No Direct Push**: NEVER push directly to `main` or `master`. No exceptions.
+- **Issue First**: Every change MUST be linked to a GitHub issue. If no issue exists, create one BEFORE starting the work (use `issue-creation` skill).
+- **Pre-Commit Validation**: ALWAYS run `make check` and ensure it passes BEFORE committing. No commit should be created with failing checks.
+- **Branching**: Always create a descriptive feature branch (e.g., `issue-#/short-description`).
+- **Pull Requests**: Every change must be submitted via a PR linked to the issue.
+- **Commits**: Use conventional commits only. No AI attribution in commit messages.
 
-### expo-tailwind-setup
+## User Skills
 
-- Always use NativeWind utility classes (`className`) over StyleSheet.create()
-- Do not use generic string classes; rely on standard Tailwind aliases
-- Follow the bold, modern UI guidelines (avoid generic colors)
-
-### expo-deployment
-
-- Pin EXPO SDK versions tightly
-- Use EAS Workflows for E2E CI/CD from branch push to app store
-
-### expo-dev-client
-
-- Always rely on continuous EAS builds instead of local prebuilds to prevent git pollution in `ios/` and `android/`
-
-### web-design-guidelines
-
-- Always include `accessibilityLabel` and `accessibilityHint` on interactive elements
-- Verify touch targets are at least 44x44 minimum
-
-## Project Conventions
-
-| File                   | Path                     | Notes                                |
-| ---------------------- | ------------------------ | ------------------------------------ |
-| AGENTS.md              | ./AGENTS.md              | Code review rules and skill registry |
-| .atl/skill-registry.md | ./.atl/skill-registry.md | This registry                        |
-
-Last updated: 2026-04-12
+| Skill                      | Trigger                                    | Description                                |
+| -------------------------- | ------------------------------------------ | ------------------------------------------ |
+| drizzle-orm                | database, schema, migration, @repo/backend | Schema patterns, relations, transactions   |
+| hono                       | backend, api, route, /v1/                  | Routing, middleware, RPC client            |
+| expo-tailwind-setup        | tailwind, nativewind, global.css, styling  | NativeWind v4 + TW v3 setup                |
+| expo-deployment            | eas build, submit, ci/cd, workflow         | EAS Build, Submit, CI/CD                   |
+| expo-dev-client            | native, build-client, testflight           | Dev builds for custom native code          |
+| frontend-design            | design, ui, screen, components             | Bold aesthetics, no generic AI stuff       |
+| vercel-react-native-skills | flashlist, performance, gpu, animation     | 38 RN optimizations, low-end device tuning |
+| web-design-guidelines      | audit, a11y, accessibility, qa             | UI audit against Vercel Guidelines         |
+| issue-creation             | issue, report, bug, feature                | GitHub issue creation workflow             |
+| branch-pr                  | pr, pull request, review                   | PR creation and review workflow            |
+| judgment-day               | juzgar, review adversarial, dual review    | Parallel adversarial review protocol       |
+| sdd-explore                | orchestrator explore, investigar           | Investigar ideas antes de un cambio        |
+| sdd-propose                | orchestrator propose, propuesta            | Crear una propuesta de cambio              |
+| sdd-spec                   | orchestrator spec, especificaciones        | Escribir especificaciones y escenarios     |
+| sdd-design                 | orchestrator design, diseño técnico        | Crear diseño técnico y arquitectura        |
+| sdd-tasks                  | orchestrator tasks, tareas                 | Desglose de tareas de implementación       |
+| sdd-apply                  | orchestrator implement, aplicar            | Implementar cambios de código              |
+| sdd-verify                 | orchestrator verify, verificar             | Validar implementación vs specs            |
+| sdd-archive                | orchestrator archive, archivar             | Sincronizar y cerrar un cambio             |
+| skill-registry             | update skills, skill registry              | Administrar este registro de habilidades   |

--- a/.gga
+++ b/.gga
@@ -34,7 +34,7 @@ EXCLUDE_PATTERNS="*.test.ts,*.spec.ts,*.test.tsx,*.spec.tsx,*.d.ts"
 
 # File containing code review rules
 # Default: AGENTS.md
-RULES_FILE="AGENTS.md"
+RULES_FILE=".atl/skill-registry.md"
 
 # Strict mode: fail if AI response is ambiguous
 # Default: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,34 +1,18 @@
-# Code Review Rules
+# Agent Hub
 
-## TypeScript
+This project uses **Agent Teams Lite (ATL)** and **Spec-Driven Development (SDD)**.
 
-- No `any` types - use proper typing
-- Use `const` over `let` when possible
-- Prefer interfaces over type aliases for objects
+## 🧠 Mission Control
 
-## React
+All technical standards, code conventions, and agent skill mappings are centralized in:
+👉 [.atl/skill-registry.md](.atl/skill-registry.md)
 
-- Use functional components with hooks
-- No `import * as React` - use named imports like `import { useState }`
-- All images must have alt text for accessibility
+## 🛠️ Operational Model
 
-## Styling
-
-- Use NativeWindd CSS utilities only
-- No inline styles or CSS-in-JS
-- No hardcoded colors - use design system tokens
+1. **Specs First**: All changes must be backed by an OpenSpec in `openspec/specs/`.
+2. **Auto-Load Skills**: The registry ensures that the AI assistant follows project-specific patterns (NativeWind v4, Drizzle, Hono).
+3. **Consistency**: Do not add technical rules here. Update the registry instead.
 
 ---
 
-## Agent Skills Registry
-
-| Skill                        | Description                       | Path                                                                                                   |
-| ---------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `drizzle-orm`                | Schema patterns, relations        | [.agent/skills/drizzle-orm/SKILL.md](.agent/skills/drizzle-orm/SKILL.md)                               |
-| `hono`                       | Routing, middleware               | [.agent/skills/hono/SKILL.md](.agent/skills/hono/SKILL.md)                                             |
-| `expo-tailwind-setup`        | NativeWind v5 + TW v4 setup       | [.agent/skills/expo-tailwind-setup/SKILL.md](.agent/skills/expo-tailwind-setup/SKILL.md)               |
-| `expo-deployment`            | EAS Build, Submit, CI/CD          | [.agent/skills/expo-deployment/SKILL.md](.agent/skills/expo-deployment/SKILL.md)                       |
-| `expo-dev-client`            | Dev builds for custom native code | [.agent/skills/expo-dev-client/SKILL.md](.agent/skills/expo-dev-client/SKILL.md)                       |
-| `frontend-design`            | Bold aesthetics                   | [.agent/skills/frontend-design/SKILL.md](.agent/skills/frontend-design/SKILL.md)                       |
-| `vercel-react-native-skills` | RN Optimizations                  | [.agent/skills/vercel-react-native-skills/SKILL.md](.agent/skills/vercel-react-native-skills/SKILL.md) |
-| `web-design-guidelines`      | Mobile QA                         | [.agent/skills/web-design-guidelines/SKILL.md](.agent/skills/web-design-guidelines/SKILL.md)           |
+_Senior Architect's Note: Keep the brain clean. One source of truth is better than two guesses._

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ eas-deploy-web:
 	cd $(MOBILE_DIR) && eas deploy
 
 eas-deploy-web-prod:
-	cd $(MOBILE_DIR) && bunx --package eas-cli eas deploy --prod
+	cd $(MOBILE_DIR) && bunx --package eas-cli@18.6.0 eas deploy --prod
 	
 # ==========================================
 # 🤖 ANDROID EMULATOR

--- a/openspec/specs/01-master-system.md
+++ b/openspec/specs/01-master-system.md
@@ -452,7 +452,7 @@ To meet the requirement of running smoothly on low-end devices while serving Web
 - **ORM:** **Drizzle ORM**. Type-safe SQL-first ORM with zero runtime overhead. Schema defined in TypeScript with `pgEnum`, `pgTable`, and type inference via `$inferSelect`/`$inferInsert`.
 - **Database:** PostgreSQL (ERD defined below).
 - **State Management:** **Zustand**. Minimal, performant state management for React Native.
-- **Styling:** **NativeWind v5** + Tailwind CSS v4 + `react-native-css`. CSS-first configuration with `@theme` tokens in CSS (not JS config). Components wrapped with `useCssElement` for `className` support.
+- **Styling:** **NativeWind v4** + Tailwind CSS v3 + `react-native-css`. Standard Tailwind configuration via `tailwind.config.js`. Components wrapped with CSS interpolation support.
 - **Monorepo:** **Bun Workspaces**. Single repository with multiple projects sharing types and validators.
 
 #### 4.0.2 Internationalization (i18n) **[MVP]**
@@ -612,7 +612,7 @@ The following agent skills are installed to enforce patterns and best practices 
 | ---------------------------- | -------------------------------------------------------------------------------- | ------------------ |
 | `drizzle-orm`                | Schema patterns, relations, transactions, migration workflow                     | Backend DB layer   |
 | `hono`                       | Routing, middleware (jwt, cors, zValidator), RPC client, `app.request()` testing | Backend API layer  |
-| `expo-tailwind-setup`        | NativeWind v5 + TW v4 + `react-native-css` wrapper setup                         | Mobile styling     |
+| `expo-tailwind-setup`        | NativeWind v4 + TW v3 + `react-native-css` wrapper setup                         | Mobile styling     |
 | `expo-deployment`            | EAS Build, Submit, Workflows for CI/CD                                           | DevOps             |
 | `expo-dev-client`            | Development builds for TestFlight (only when custom native code needed)          | DevOps             |
 | `frontend-design`            | Bold aesthetic direction — NO generic AI aesthetics                              | Mobile UI design   |


### PR DESCRIPTION
Closes #86

### Summary
This PR centralizes all project technical standards, agent behaviors, and workflow rules into the Skill Registry.

### Changes Table
| File | Change |
|------|--------|
| `.atl/skill-registry.md` | Unified source of truth for standards and skills. |
| `AGENTS.md` | Refactored as a high-level hub. |
| `.gga` | Pointed to the registry for automated reviews. |
| `openspec/specs/01-master-system.md` | Corrected stack versions (NativeWind v4 + Tailwind v3). |

### Test Plan
- [x] Ran `make check` (pre-commit hook verified).
- [x] Verified GGA reads from the new registry.
- [x] Validated issue-first workflow by creating issue #86.