### PR TITLE
feat(workflow): integrate husky for automated shared git hooks

### DIFF
--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -5,6 +5,7 @@
 ### Global Context
 
 - **Language Policy**: ALL technical metadata, including code comments, docstrings, and Git metadata (Commit messages, PR descriptions), MUST be written in **English**. The project's "Technical Esperanto" is English, regardless of the conversation language.
+- **Command Policy: Make-First**: ALWAYS use `make <command>` for ANY development execution. Direct use of `bun`, `npm`, or `yarn` is STRICTLY PROHIBITED. If a required command is missing from the `Makefile`, ASK the user to add it first.
 
 ### TypeScript
 
@@ -41,7 +42,6 @@
 - **No Direct Push**: NEVER push directly to `main` or `master`. No exceptions.
 - **Issue First**: Every change MUST be linked to a GitHub issue. If no issue exists, create one BEFORE starting the work (use `issue-creation` skill).
 - **Pre-Commit Validation**: ALWAYS run `make check` and ensure it passes BEFORE committing. No commit should be created with failing checks.
-- **Command Policy: Make-First**: ALWAYS prefer `make <command>` over direct `bun` or `npm` commands. If a required command is missing from the `Makefile`, ASK the user to add it before proceeding.
 - **Branching**: Always create a descriptive feature branch (e.g., `issue-#/short-description`).
 - **Pull Requests**: Every change must be submitted via a PR linked to the issue.
 - **Commits**: Use conventional commits only. No AI attribution in commit messages.

--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -41,6 +41,7 @@
 - **No Direct Push**: NEVER push directly to `main` or `master`. No exceptions.
 - **Issue First**: Every change MUST be linked to a GitHub issue. If no issue exists, create one BEFORE starting the work (use `issue-creation` skill).
 - **Pre-Commit Validation**: ALWAYS run `make check` and ensure it passes BEFORE committing. No commit should be created with failing checks.
+- **Command Policy: Make-First**: ALWAYS prefer `make <command>` over direct `bun` or `npm` commands. If a required command is missing from the `Makefile`, ASK the user to add it before proceeding.
 - **Branching**: Always create a descriptive feature branch (e.g., `issue-#/short-description`).
 - **Pull Requests**: Every change must be submitted via a PR linked to the issue.
 - **Commits**: Use conventional commits only. No AI attribution in commit messages.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# ======== REWILDING CONNECT HOOKS ========
+# Run full check suite (Typecheck, Lint, Format, GGA)
+make check || exit 1
+
+# Re-stage any files modified by automated formatting (Prettier)
+git add -u
+# ========================================

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "impenetrable-connect",
       "devDependencies": {
+        "husky": "^9.1.7",
         "prettier": "^3.5.1",
       },
     },
@@ -1129,6 +1130,8 @@
     "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "hyphenate-style-name": ["hyphenate-style-name@1.1.0", "", {}, "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="],
 

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "dev": "bun run --filter '*' dev",
     "build": "bun run --filter '*' build",
     "lint": "bun run --filter '*' lint",
-    "format": "bunx prettier --write ."
+    "format": "bunx prettier --write .",
+    "prepare": "husky"
   },
   "devDependencies": {
+    "husky": "^9.1.7",
     "prettier": "^3.5.1"
   }
 }


### PR DESCRIPTION
Closes #91

### Changes
- Integrated `husky` for automated git hooks at monorepo root.
- Formalized `Global Context` in `skill-registry.md`:
  - **Language Policy**: Technical metadata MUST be in English.
  - **Command Policy (Make-First)**: `make` is the mandatory interface for all commands; manual `bun/npm/yarn` is prohibited.
- Ensured all technical metadata is in English.

### Verification
✅ PASS: Husky pre-commit hook validated during push.
✅ PASS: make check successful.
