### PR TITLE
chore(atl): enforce fresh main start protocol

### DIFF
--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -62,7 +62,9 @@
 - **Issue First**: Every change MUST be linked to a GitHub issue. If no issue exists, create one BEFORE starting the work (use `issue-creation` skill).
 - **Pre-Commit Validation**: ALWAYS run `make check` and ensure it passes BEFORE committing. No commit should be created with failing checks.
 - **No Verification Bypass**: NEVER use `--no-verify` or any mechanism to bypass Git hooks (linter, tests, `gga`). If a check fails, the root cause MUST be investigated and fixed. Bypassing quality gates is STRICTLY PROHIBITED.
-- **Branching**: Always create a descriptive feature branch (e.g., `issue-#/short-description`).
+- **Branching**:
+  - **Always Start from Fresh Main**: BEFORE starting any new feature (creating a branch or beginning work), MUST switch to `main`, pull the latest remote changes (`git pull origin main`), and ONLY THEN create the new feature branch. Starting from a stale state is STRICTLY PROHIBITED.
+  - Always create a descriptive feature branch (e.g., `issue-#/short-description`).
 - **Pull Requests**: Every change must be submitted via a PR linked to the issue.
 - **Commits**: Use conventional commits only. No AI attribution in commit messages.
 - **Pull Request Standards**:


### PR DESCRIPTION
Closes #102.

Summary of changes:
- **Git Workflow**: Added mandatory 'Always Start from Fresh Main' protocol to the skill registry. 
- **Rationale**: Ensures all work begins on top of the latest project state to minimize merge conflicts.