### PR TITLE
chore: final rebranding to impenetrable and immutable mock refactor

### DIFF
--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -1,4 +1,4 @@
-# Skill Registry - rewilding-connect
+# Skill Registry - impenetrable-connect
 
 ## Project Standards
 

--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -4,6 +4,8 @@
 
 ### Global Context
 
+- **AI Review Formatting (gga)**: MANDATORY: Every automated review MUST start with `STATUS: PASSED` or `STATUS: FAILED` on the **VERY FIRST LINE** of the output. No exceptions. Detailed analysis must follow ONLY after this status line.
+
 - **Language Policy**: ALL technical metadata, including code comments, docstrings, and Git metadata (Commit messages, PR descriptions), MUST be written in **English**. The project's "Technical Esperanto" is English, regardless of the conversation language.
 - **Command Policy: Make-First**: ALWAYS use `make <command>` for ANY development execution. Direct use of `bun`, `npm`, or `yarn` is STRICTLY PROHIBITED. If a required command is missing from the `Makefile`, ASK the user to add it first.
 - **Code Quality & Formatting (Prettier-First Policy)**: ALL code files MUST strictly adhere to the project's `.prettierrc` configuration.
@@ -100,7 +102,6 @@
   - **Label Verification**: ALWAYS run `gh label list` before adding labels to a PR to ensure compliance with project-specific naming (e.g., `type:feature` vs `type:feat`).
   - Descriptions must not paste full logs; use the summary format instead.
   - MUST link to an approved issue ("Closes #XX").
-- **AI Review Formatting (gga)**: When performing an automated code review via `gga`, the response MUST start with `STATUS: PASSED` or `STATUS: FAILED` on the VERY FIRST LINE of the output. Concise justifications and key verifications should follow below. This ensures the automated gate can reliably parse the result.
 - **Post-Merge Cleanup**: When the user says "mergeado" (merged), the agent MUST:
   1. Confirm the PR and its linked issue are closed (`gh pr view` / `gh issue view`).
   2. Switch to `main` branch.

--- a/apps/mobile/src/mocks/orders.ts
+++ b/apps/mobile/src/mocks/orders.ts
@@ -12,7 +12,7 @@ import { MOCK_VENTURES } from "./ventures.data";
  */
 
 // Shared in-memory state for orders and reservations
-const GLOBAL_ORDERS_KEY = "__REWILDING_MOCK_ORDERS_STATE__";
+const GLOBAL_ORDERS_KEY = "__IMPENETRABLE_MOCK_ORDERS_STATE__";
 
 // Initialize global orders state if not already present
 const ordersStateContainer = globalThis as unknown as {
@@ -44,22 +44,26 @@ const getEffectiveUserId = () => {
 export function getAllMockOrders(): Order[] {
   return ordersState.orders.map((order) => {
     const reservation = ordersState.reservations.find((r) => r.id === order.reservation_id);
-    if (reservation) {
-      reservation.user = MOCK_USERS.find((u) => u.id === reservation.user_id);
-    }
+    const enrichedReservation = reservation
+      ? { ...reservation, user: MOCK_USERS.find((u) => u.id === reservation.user_id) }
+      : undefined;
+
     const enrichedItems = (order.items || []).map((item) => ({
       ...item,
       catalog_item: MOCK_CATALOG_ITEMS[item.catalog_item_id],
     }));
+
     const confirmedVenture = order.confirmed_venture_id
       ? MOCK_VENTURES.find((v) => v.id === order.confirmed_venture_id)
       : undefined;
+
     const currentOfferVenture = order.current_offer_venture_id
       ? MOCK_VENTURES.find((v) => v.id === order.current_offer_venture_id)
       : undefined;
+
     return {
       ...order,
-      reservation,
+      reservation: enrichedReservation,
       items: enrichedItems,
       confirmed_venture: confirmedVenture,
       current_offer_venture: currentOfferVenture,
@@ -81,22 +85,26 @@ export function getMockOrders(): Order[] {
 
   return orders.map((order) => {
     const reservation = ordersState.reservations.find((r) => r.id === order.reservation_id);
-    if (reservation) {
-      reservation.user = MOCK_USERS.find((u) => u.id === reservation.user_id);
-    }
+    const enrichedReservation = reservation
+      ? { ...reservation, user: MOCK_USERS.find((u) => u.id === reservation.user_id) }
+      : undefined;
+
     const enrichedItems = (order.items || []).map((item) => ({
       ...item,
       catalog_item: MOCK_CATALOG_ITEMS[item.catalog_item_id],
     }));
+
     const confirmedVenture = order.confirmed_venture_id
       ? MOCK_VENTURES.find((v) => v.id === order.confirmed_venture_id)
       : undefined;
+
     const currentOfferVenture = order.current_offer_venture_id
       ? MOCK_VENTURES.find((v) => v.id === order.current_offer_venture_id)
       : undefined;
+
     return {
       ...order,
-      reservation,
+      reservation: enrichedReservation,
       items: enrichedItems,
       confirmed_venture: confirmedVenture,
       current_offer_venture: currentOfferVenture,
@@ -138,8 +146,8 @@ export const getMockOrderById = (id: number): Order | undefined => {
  * Update an order status
  */
 export function updateMockOrderStatus(id: number, status: Order["global_status"]) {
-  const order = ordersState.orders.find((o: Order) => Number(o.id) === Number(id));
-  if (order) {
-    order.global_status = status;
-  }
+  ordersState.orders = ordersState.orders.map((o: Order) =>
+    Number(o.id) === Number(id) ? { ...o, global_status: status } : o,
+  );
+  logger.info(`[MOCK] Updated order status ${id} to ${status}`);
 }

--- a/openspec/changes/archive/2026-04-20-backend-init-health-check/proposal.md
+++ b/openspec/changes/archive/2026-04-20-backend-init-health-check/proposal.md
@@ -10,7 +10,7 @@ Initialize the backend application within the monorepo structure and implement t
 
 ## 2. Context
 
-The `rewilding-connect` project is a Bun-based monorepo. While the mobile app and shared packages are present, the backend infrastructure (Hono + Drizzle) is not yet initialized.
+The `impenetrable-connect` project is a Bun-based monorepo. While the mobile app and shared packages are present, the backend infrastructure (Hono + Drizzle) is not yet initialized.
 
 ## 3. Goals
 


### PR DESCRIPTION
## Description
Final cleanup after the backend-init merge to ensure monorepo consistency and architectural standards.

## Key Changes
- Renamed legacy "REWILDING" references to "IMPENETRABLE" in registry, hooks, and mocks.
- Refactored `apps/mobile/src/mocks/orders.ts` for full immutability and observability.
- Prioritized GGA formatting rules in the skill registry to improve CI/CD reliability.

Closes #122 (final bits)