### PR TITLE
fix(mobile): ensure reservations are created in mock mode for visibility

### DIFF
--- a/apps/mobile/src/__tests__/catalog-visibility.test.ts
+++ b/apps/mobile/src/__tests__/catalog-visibility.test.ts
@@ -1,0 +1,34 @@
+import { CatalogService } from "../services/catalog.service";
+import { mockSetCurrentUser } from "../services/auth-state";
+import { MOCK_USERS } from "../mocks/users.data";
+
+describe("Catalog Visibility Integration", () => {
+  const touristUser = MOCK_USERS.find((u) => u.user_type === "TOURIST")!;
+
+  beforeEach(() => {
+    mockSetCurrentUser(touristUser);
+  });
+
+  it("should make a new order visible in the order list after placement", async () => {
+    const initialOrders = await CatalogService.getOrders();
+    const initialCount = initialOrders.length;
+
+    // Place a new order
+    const date = new Date();
+    const moment = "BREAKFAST";
+    const items = [{ catalog_item_id: 1, quantity: 1 }];
+
+    const newOrder = await CatalogService.placeOrder(date, moment, items, "Test order");
+
+    expect(newOrder).toBeDefined();
+    expect(newOrder.id).toBeDefined();
+
+    // Verify it appears in the orders list
+    const updatedOrders = await CatalogService.getOrders();
+
+    // THIS IS EXPECTED TO FAIL BEFORE THE FIX
+    const foundOrder = updatedOrders.find((o) => o.id === newOrder.id);
+    expect(foundOrder).toBeDefined();
+    expect(updatedOrders.length).toBe(initialCount + 1);
+  });
+});

--- a/apps/mobile/src/mocks/orders.ts
+++ b/apps/mobile/src/mocks/orders.ts
@@ -151,3 +151,26 @@ export function updateMockOrderStatus(id: number, status: Order["global_status"]
   );
   logger.info(`[MOCK] Updated order status ${id} to ${status}`);
 }
+
+/**
+ * Add a reservation to the mock collection
+ */
+export function addMockReservation(reservation: Omit<Reservation, "id">): Reservation {
+  const newReservation: Reservation = {
+    id: Math.floor(Math.random() * 100000),
+    ...reservation,
+  };
+  ordersState.reservations = [newReservation, ...ordersState.reservations];
+  logger.info("[MOCK API] Created reservation:", { ...newReservation });
+  return newReservation;
+}
+
+/**
+ * Update a mock reservation with new data
+ */
+export function updateMockReservation(id: number, updates: Partial<Reservation>) {
+  ordersState.reservations = ordersState.reservations.map((r: Reservation) =>
+    Number(r.id) === Number(id) ? { ...r, ...updates } : r,
+  );
+  logger.info(`[MOCK] Updated reservation ${id} (new array reference created)`);
+}

--- a/apps/mobile/src/services/catalog.service.ts
+++ b/apps/mobile/src/services/catalog.service.ts
@@ -8,11 +8,17 @@
 
 import { z } from "zod";
 
-import type { Order, ServiceMoment } from "@repo/shared";
+import type { Order, Reservation, ServiceMoment } from "@repo/shared";
 import { ServiceMomentSchema } from "@repo/shared";
 import { MOCK_CATALOG_SERVICES, type CatalogServiceItem } from "../mocks/catalog";
-import { addMockOrder, getMockOrders, updateMockOrder } from "../mocks/orders";
-import { isMockUserLoggedIn } from "../mocks/users";
+import {
+  addMockOrder,
+  addMockReservation,
+  getMockOrders,
+  updateMockOrder,
+  updateMockReservation,
+} from "../mocks/orders";
+import { isMockUserLoggedIn, getMockUserId } from "../mocks/users";
 import { logger } from "./logger.service";
 import env from "../config/env";
 import { toISODate } from "../logic/formatters";
@@ -92,10 +98,17 @@ const MockCatalogService: CatalogServiceInterface = {
     if (!firstService) throw new Error("Service not found");
 
     const orderId = Date.now();
+    const reservation = addMockReservation({
+      user_id: isMockUserLoggedIn() ? getMockUserId() : "unknown",
+      service_date: date,
+      time_of_day: moment,
+      status: "CREATED",
+      created_at: new Date(),
+    });
 
     const newOrder: Order = {
       id: orderId,
-      reservation_id: Math.floor(Math.random() * 100000),
+      reservation_id: reservation.id,
       catalog_type_id: firstService.catalog_category_id,
       confirmed_venture_id: null,
       notes: notes ?? null,
@@ -150,16 +163,14 @@ const MockCatalogService: CatalogServiceInterface = {
       // In a real system, we might move the order to a different reservation
       // or update the existing one. For mocks, we'll handle this by updating the reservation.
       const { getMockOrderById } = await import("../mocks/orders");
-      const order = getMockOrderById(Number(id));
-      if (order?.reservation_id) {
+      const foundOrder = getMockOrderById(Number(id));
+      if (foundOrder?.reservation_id) {
         // This is a bit of a shortcut for the mock, updating the reservation in state
-        const { getMockReservations } = await import("../mocks/orders");
-        const reservations = getMockReservations();
-        const res = reservations.find((r) => r.id === order.reservation_id);
-        if (res) {
-          if (input.date) res.service_date = input.date;
-          if (input.moment) res.time_of_day = input.moment;
-        }
+        const reservationUpdates: Partial<Reservation> = {};
+        if (input.date) reservationUpdates.service_date = input.date;
+        if (input.moment) reservationUpdates.time_of_day = input.moment;
+
+        updateMockReservation(foundOrder.reservation_id, reservationUpdates);
       }
     }
 

--- a/openspec/changes/fix-reservation-visibility/design.md
+++ b/openspec/changes/fix-reservation-visibility/design.md
@@ -1,0 +1,28 @@
+# Design: Fix Reservation Visibility Bug
+
+## Approach
+We need to ensure that the mock state maintains referential integrity between Orders and Reservations.
+
+### Changes
+
+#### 1. `apps/mobile/src/mocks/orders.ts`
+- Add `addMockReservation(reservation: Omit<Reservation, "id">)` function.
+- This function will:
+  - Generate a new ID.
+  - Push the reservation to `ordersState.reservations`.
+  - Return the new reservation.
+
+#### 2. `apps/mobile/src/services/catalog.service.ts`
+- Update `placeOrder` to:
+  - Call `addMockReservation` with the `date`, `moment`, and `user_id`.
+  - Use the returned reservation's ID for the new order's `reservation_id`.
+  - Call `addMockOrder` as before.
+
+## Architecture Decisions
+- **ADR-001: Mock State Integrity**: Mock services should simulate database behavior by maintaining linked entities in their internal state. This ensures that filtering logic (like `getMockOrders`) works correctly during development.
+
+## Implementation Plan
+1. Create a failing test in `apps/mobile/src/services/__tests__/catalog.service.test.ts`.
+2. Update `apps/mobile/src/mocks/orders.ts` to include `addMockReservation`.
+3. Update `apps/mobile/src/services/catalog.service.ts` to use `addMockReservation`.
+4. Verify the test passes.

--- a/openspec/changes/fix-reservation-visibility/spec.md
+++ b/openspec/changes/fix-reservation-visibility/spec.md
@@ -1,0 +1,19 @@
+# Spec: Fix Reservation Visibility Bug
+
+## Problem
+When a tourist places an order in mock mode, the order is created with a random `reservation_id` that does not exist in the mock `reservations` collection.
+Because `getMockOrders()` filters orders by looking up their associated reservation's `user_id`, these new orders are filtered out and do not appear in the order list.
+
+## Requirements
+- When an order is placed in mock mode, a corresponding `Reservation` must be created.
+- The `Reservation` must have the correct `user_id` of the logged-in user.
+- The `Order` must link to this new `Reservation`.
+- `getMockOrders()` must return the newly created order.
+
+## Scenarios
+### Scenario 1: New order visibility
+**Given** a logged-in tourist
+**When** the tourist places an order for "Today" and "Breakfast"
+**Then** a new `Reservation` should be added to the mock state
+**And** a new `Order` should be added to the mock state linked to that reservation
+**And** `getMockOrders()` should include the new order

--- a/openspec/changes/fix-reservation-visibility/tasks.md
+++ b/openspec/changes/fix-reservation-visibility/tasks.md
@@ -1,0 +1,6 @@
+# Tasks: Fix Reservation Visibility Bug
+
+- [x] Create failing test case in `apps/mobile/src/__tests__/catalog-visibility.test.ts` <!-- id: 1 -->
+- [x] Add `addMockReservation` to `apps/mobile/src/mocks/orders.ts` <!-- id: 2 -->
+- [x] Update `MockCatalogService.placeOrder` in `apps/mobile/src/services/catalog.service.ts` <!-- id: 3 -->
+- [x] Verify test passes and fix is robust <!-- id: 4 -->


### PR DESCRIPTION
Closes #125

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

### Summary
Fixed a bug where new orders were not appearing in the orders list in mock mode by ensuring the associated reservation is also created in the mock state.

### Test Summary
✅ PASS: 49 total tests, make check successful

### Changes Table
| File | Change |
|------|--------|
| `apps/mobile/src/mocks/orders.ts` | Added `addMockReservation` and `updateMockReservation` |
| `apps/mobile/src/services/catalog.service.ts` | Use `addMockReservation` in `placeOrder` |
| `apps/mobile/src/__tests__/catalog-visibility.test.ts` | New integration test |

### Test Plan
- [x] Manually tested the affected functionality
- [x] All 49 tests passed in the mobile app