### PR TITLE
ci: update github actions to node 24 and enable caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,13 @@ jobs:
       CI: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+          cache: true
 
       - name: Install Dependencies
         run: make setup

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -16,12 +16,13 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+          cache: true
 
       - name: Install Dependencies
         run: make setup


### PR DESCRIPTION
Closes #135

### PR Type
- [x] Maintenance/tooling (`type:chore`)

### Summary
- Updated `actions/checkout` to `v6` for Node 24 support.
- Updated `oven-sh/setup-bun` to `v2` for Node 24 support.
- Enabled native Bun dependency caching to speed up workflows.

### Test Summary
✅ PASS: Workflow syntax is valid.

### Changes Table
| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Update actions and enable cache |
| `.github/workflows/deploy-web.yml` | Update actions and enable cache |

### Test Plan
- [x] Verified YAML syntax locally.
- [x] Verified updated actions support Node 24.