### PR TITLE
chore: configure eas web caching headers

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -42,7 +42,26 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     resizeMode: "contain",
     backgroundColor: "#fcf9f2", // Uses surface color from design system
   },
-  plugins: ["expo-localization", "expo-router", "@react-native-community/datetimepicker"],
+  plugins: [
+    "expo-localization",
+    [
+      "expo-router",
+      {
+        headers: {
+          // EXPLANATION OF CACHE-CONTROL "no-cache":
+          // The EAS Hosting default is a 1-hour cache which causes stale web deployments.
+          // Using "no-cache" is the optimal middle-ground for SPAs:
+          // It DOES allow the browser to cache the file locally, but STRICTLY REQUIRES
+          // the browser to validate with the server (via ETag) before using it.
+          // - If no new deploy was made -> Server returns HTTP 304, browser loads from cache instantly.
+          // - If a new deploy was made -> Server returns HTTP 200, browser downloads the fresh file.
+          // This guarantees users never see a stale index.html without sacrificing load speed.
+          "Cache-Control": "no-cache",
+        },
+      },
+    ],
+    "@react-native-community/datetimepicker",
+  ],
   ios: {
     supportsTablet: true,
     bundleIdentifier: getUniqueIdentifier(),


### PR DESCRIPTION
Closes #148

## Description
This PR addresses the frustrating caching issue on EAS Hosting web deployments where users are stuck seeing stale versions of the SPA. 

### Before
The default EAS Hosting behavior caches `index.html` for 3600 seconds (1 hour). This means when a new deployment goes out to `master`, browsers refuse to fetch the new `index.html` from the network, requiring users to perform a hard refresh to see the changes.

### After
We configured the `expo-router` plugin to inject a `Cache-Control: no-cache` server header for HTML files. This acts as an optimal middle-ground strategy: it allows the browser to cache the file locally, but **strictly mandates an ETag validation** with the server before using the cached version. If there are no changes, it loads instantly (HTTP 304). If there is a new deploy, it downloads the fresh file (HTTP 200). 

## Changes Made
- Added `Cache-Control: no-cache` header to `expo-router` in `app.config.ts`.
- Added a detailed architectural comment explaining the ETag validation mechanism for future developers.

## Tests
- [x] Code follows strict typing and architectural guidelines.
- [x] Tested the local configuration.
- [x] PR is linked to the approved issue #148.
