### PR TITLE
feat(db): migrate database schema to custom schema

### DIFF
--- a/apps/backend/drizzle.config.ts
+++ b/apps/backend/drizzle.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "drizzle-kit";
 import { getCLIConfig } from "./src/config/env";
+import { SCHEMA_NAME } from "./src/db/schema/base";
 
 const config = getCLIConfig();
 
@@ -10,4 +11,5 @@ export default defineConfig({
   dbCredentials: {
     url: config.directUrl,
   },
+  schemaFilter: [SCHEMA_NAME],
 });

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -8,7 +8,7 @@
     "test": "bun test --preload ./test-setup.ts",
     "lint": "bunx eslint src",
     "typecheck": "bunx tsc --noEmit",
-    "db:push": "drizzle-kit push",
+    "db:push": "bun run src/db/pre-push.ts && drizzle-kit push",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "bun run src/db/migrate.ts && bun run src/db/db-setup-advanced.ts",
     "db:seed": "bun run src/db/seed.ts",

--- a/apps/backend/src/db/db-setup-advanced.ts
+++ b/apps/backend/src/db/db-setup-advanced.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import { createDb } from "./index";
 import { getAppConfig } from "../config/env";
 import { logger } from "../services/logger.service";
+import { SCHEMA_NAME } from "./schema/base";
 
 /**
  * Database Setup Script: Applies advanced PostgreSQL patterns that are not
@@ -14,35 +15,39 @@ async function setupAdvancedPatterns() {
     const config = getAppConfig();
     const db = createDb(config.databaseUrl);
 
-    // 1. Global Trigger Function for updated_at
+    // 1. Global Trigger Function for updated_at inside custom schema
     logger.info("  - Creating update_updated_at_column function...");
-    await db.execute(sql`
-      CREATE OR REPLACE FUNCTION update_updated_at_column()
+    await db.execute(
+      sql.raw(`
+      CREATE OR REPLACE FUNCTION ${SCHEMA_NAME}.update_updated_at_column()
       RETURNS TRIGGER AS $$
       BEGIN
           NEW.zzz_updated_at = NOW();
           RETURN NEW;
       END;
       $$ language 'plpgsql';
-    `);
+    `),
+    );
 
-    // 2. Enable RLS and Triggers for each table
+    // 2. Enable RLS and Triggers for each table in the custom schema
     const tables = ["users", "projects", "ventures", "refresh_tokens"];
 
     for (const table of tables) {
       logger.info(`  - Setting up ${table}...`);
 
-      // Enable RLS
-      await db.execute(sql.raw(`ALTER TABLE ${table} ENABLE ROW LEVEL SECURITY;`));
+      // Enable RLS on schema-qualified table
+      await db.execute(sql.raw(`ALTER TABLE ${SCHEMA_NAME}.${table} ENABLE ROW LEVEL SECURITY;`));
 
       // Create Trigger (Drop first to avoid duplicates)
-      await db.execute(sql.raw(`DROP TRIGGER IF EXISTS trg_update_updated_at ON ${table};`));
+      await db.execute(
+        sql.raw(`DROP TRIGGER IF EXISTS trg_update_updated_at ON ${SCHEMA_NAME}.${table};`),
+      );
       await db.execute(
         sql.raw(`
         CREATE TRIGGER trg_update_updated_at
-        BEFORE UPDATE ON ${table}
+        BEFORE UPDATE ON ${SCHEMA_NAME}.${table}
         FOR EACH ROW
-        EXECUTE FUNCTION update_updated_at_column();
+        EXECUTE FUNCTION ${SCHEMA_NAME}.update_updated_at_column();
       `),
       );
     }

--- a/apps/backend/src/db/migrate.ts
+++ b/apps/backend/src/db/migrate.ts
@@ -4,6 +4,7 @@ import postgres from "postgres";
 import path from "path";
 import { logger } from "../services/logger.service";
 import { getAppConfig } from "../config/env";
+import { SCHEMA_NAME } from "./schema/base";
 
 /**
  * Database Migration Script
@@ -23,6 +24,9 @@ async function runMigration() {
   const db = drizzle(migrationClient);
 
   try {
+    // Explicitly create the custom schema if it doesn't exist
+    await migrationClient.unsafe(`CREATE SCHEMA IF NOT EXISTS ${SCHEMA_NAME};`);
+
     await migrate(db, {
       migrationsFolder: path.join(__dirname, "migrations"),
     });

--- a/apps/backend/src/db/migrations/0000_initial-schema.sql
+++ b/apps/backend/src/db/migrations/0000_initial-schema.sql
@@ -1,5 +1,5 @@
-CREATE TYPE "public"."user_role" AS ENUM('ADMIN', 'ENTREPRENEUR', 'TOURIST');--> statement-breakpoint
-CREATE TABLE "projects" (
+CREATE TYPE "impenetrable_connect"."user_role" AS ENUM('ADMIN', 'ENTREPRENEUR', 'TOURIST');--> statement-breakpoint
+CREATE TABLE "impenetrable_connect"."projects" (
 	"zzz_id" serial PRIMARY KEY NOT NULL,
 	"zzz_name" varchar(100) NOT NULL,
 	"zzz_default_language" varchar(10) DEFAULT 'es' NOT NULL,
@@ -12,7 +12,7 @@ CREATE TABLE "projects" (
 	"zzz_deleted_at" timestamp
 );
 --> statement-breakpoint
-CREATE TABLE "users" (
+CREATE TABLE "impenetrable_connect"."users" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"email" varchar(255),
 	"alias" varchar(50),
@@ -20,7 +20,7 @@ CREATE TABLE "users" (
 	"first_name" varchar(100),
 	"last_name" varchar(100),
 	"phone_number" varchar(20),
-	"role" "user_role" DEFAULT 'ENTREPRENEUR' NOT NULL,
+	"role" "impenetrable_connect"."user_role" DEFAULT 'ENTREPRENEUR' NOT NULL,
 	"zzz_failed_login_attempts" integer DEFAULT 0 NOT NULL,
 	"zzz_last_login_at" timestamp,
 	"is_active" boolean DEFAULT true NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE "users" (
 	CONSTRAINT "users_alias_unique" UNIQUE("alias")
 );
 --> statement-breakpoint
-CREATE TABLE "ventures" (
+CREATE TABLE "impenetrable_connect"."ventures" (
 	"id" serial PRIMARY KEY NOT NULL,
 	"name" varchar(255) NOT NULL,
 	"owner_id" uuid NOT NULL,
@@ -45,7 +45,7 @@ CREATE TABLE "ventures" (
 	"zzz_deleted_at" timestamp
 );
 --> statement-breakpoint
-CREATE TABLE "refresh_tokens" (
+CREATE TABLE "impenetrable_connect"."refresh_tokens" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"user_id" uuid NOT NULL,
 	"token_hash" text NOT NULL,
@@ -56,7 +56,7 @@ CREATE TABLE "refresh_tokens" (
 	"zzz_deleted_at" timestamp
 );
 --> statement-breakpoint
-CREATE TABLE "venture_members" (
+CREATE TABLE "impenetrable_connect"."venture_members" (
 	"id" serial PRIMARY KEY NOT NULL,
 	"venture_id" integer NOT NULL,
 	"user_id" uuid NOT NULL,
@@ -66,7 +66,7 @@ CREATE TABLE "venture_members" (
 	"zzz_deleted_at" timestamp
 );
 --> statement-breakpoint
-CREATE TABLE "product_categories" (
+CREATE TABLE "impenetrable_connect"."product_categories" (
 	"zzz_id" serial PRIMARY KEY NOT NULL,
 	"zzz_project_id" integer NOT NULL,
 	"zzz_name_i18n" jsonb NOT NULL,
@@ -77,7 +77,7 @@ CREATE TABLE "product_categories" (
 	"zzz_deleted_at" timestamp
 );
 --> statement-breakpoint
-CREATE TABLE "products" (
+CREATE TABLE "impenetrable_connect"."products" (
 	"zzz_id" serial PRIMARY KEY NOT NULL,
 	"zzz_product_category_id" integer NOT NULL,
 	"zzz_name_i18n" jsonb NOT NULL,
@@ -92,10 +92,10 @@ CREATE TABLE "products" (
 	"zzz_deleted_at" timestamp
 );
 --> statement-breakpoint
-ALTER TABLE "ventures" ADD CONSTRAINT "ventures_owner_id_users_id_fk" FOREIGN KEY ("owner_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "ventures" ADD CONSTRAINT "ventures_zzz_project_id_projects_zzz_id_fk" FOREIGN KEY ("zzz_project_id") REFERENCES "public"."projects"("zzz_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "refresh_tokens" ADD CONSTRAINT "refresh_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "venture_members" ADD CONSTRAINT "venture_members_venture_id_ventures_id_fk" FOREIGN KEY ("venture_id") REFERENCES "public"."ventures"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "venture_members" ADD CONSTRAINT "venture_members_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "product_categories" ADD CONSTRAINT "product_categories_zzz_project_id_projects_zzz_id_fk" FOREIGN KEY ("zzz_project_id") REFERENCES "public"."projects"("zzz_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "products" ADD CONSTRAINT "products_zzz_product_category_id_product_categories_zzz_id_fk" FOREIGN KEY ("zzz_product_category_id") REFERENCES "public"."product_categories"("zzz_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "impenetrable_connect"."ventures" ADD CONSTRAINT "ventures_owner_id_users_id_fk" FOREIGN KEY ("owner_id") REFERENCES "impenetrable_connect"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "impenetrable_connect"."ventures" ADD CONSTRAINT "ventures_zzz_project_id_projects_zzz_id_fk" FOREIGN KEY ("zzz_project_id") REFERENCES "impenetrable_connect"."projects"("zzz_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "impenetrable_connect"."refresh_tokens" ADD CONSTRAINT "refresh_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "impenetrable_connect"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "impenetrable_connect"."venture_members" ADD CONSTRAINT "venture_members_venture_id_ventures_id_fk" FOREIGN KEY ("venture_id") REFERENCES "impenetrable_connect"."ventures"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "impenetrable_connect"."venture_members" ADD CONSTRAINT "venture_members_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "impenetrable_connect"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "impenetrable_connect"."product_categories" ADD CONSTRAINT "product_categories_zzz_project_id_projects_zzz_id_fk" FOREIGN KEY ("zzz_project_id") REFERENCES "impenetrable_connect"."projects"("zzz_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "impenetrable_connect"."products" ADD CONSTRAINT "products_zzz_product_category_id_product_categories_zzz_id_fk" FOREIGN KEY ("zzz_product_category_id") REFERENCES "impenetrable_connect"."product_categories"("zzz_id") ON DELETE no action ON UPDATE no action;

--- a/apps/backend/src/db/migrations/meta/0000_snapshot.json
+++ b/apps/backend/src/db/migrations/meta/0000_snapshot.json
@@ -1,12 +1,12 @@
 {
-  "id": "66a73ccf-49ec-43a3-bbc0-2043ebf0f6d4",
+  "id": "4a2c51c9-8740-4c5a-a671-c95fbdd9cdc2",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
-    "public.projects": {
+    "impenetrable_connect.projects": {
       "name": "projects",
-      "schema": "",
+      "schema": "impenetrable_connect",
       "columns": {
         "zzz_id": {
           "name": "zzz_id",
@@ -84,9 +84,9 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.users": {
+    "impenetrable_connect.users": {
       "name": "users",
-      "schema": "",
+      "schema": "impenetrable_connect",
       "columns": {
         "id": {
           "name": "id",
@@ -134,7 +134,7 @@
         "role": {
           "name": "role",
           "type": "user_role",
-          "typeSchema": "public",
+          "typeSchema": "impenetrable_connect",
           "primaryKey": false,
           "notNull": true,
           "default": "'ENTREPRENEUR'"
@@ -199,9 +199,9 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.ventures": {
+    "impenetrable_connect.ventures": {
       "name": "ventures",
-      "schema": "",
+      "schema": "impenetrable_connect",
       "columns": {
         "id": {
           "name": "id",
@@ -282,6 +282,7 @@
           "name": "ventures_owner_id_users_id_fk",
           "tableFrom": "ventures",
           "tableTo": "users",
+          "schemaTo": "impenetrable_connect",
           "columnsFrom": ["owner_id"],
           "columnsTo": ["id"],
           "onDelete": "no action",
@@ -291,6 +292,7 @@
           "name": "ventures_zzz_project_id_projects_zzz_id_fk",
           "tableFrom": "ventures",
           "tableTo": "projects",
+          "schemaTo": "impenetrable_connect",
           "columnsFrom": ["zzz_project_id"],
           "columnsTo": ["zzz_id"],
           "onDelete": "no action",
@@ -303,9 +305,9 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.refresh_tokens": {
+    "impenetrable_connect.refresh_tokens": {
       "name": "refresh_tokens",
-      "schema": "",
+      "schema": "impenetrable_connect",
       "columns": {
         "id": {
           "name": "id",
@@ -365,6 +367,7 @@
           "name": "refresh_tokens_user_id_users_id_fk",
           "tableFrom": "refresh_tokens",
           "tableTo": "users",
+          "schemaTo": "impenetrable_connect",
           "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
           "onDelete": "no action",
@@ -377,9 +380,9 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.venture_members": {
+    "impenetrable_connect.venture_members": {
       "name": "venture_members",
-      "schema": "",
+      "schema": "impenetrable_connect",
       "columns": {
         "id": {
           "name": "id",
@@ -433,6 +436,7 @@
           "name": "venture_members_venture_id_ventures_id_fk",
           "tableFrom": "venture_members",
           "tableTo": "ventures",
+          "schemaTo": "impenetrable_connect",
           "columnsFrom": ["venture_id"],
           "columnsTo": ["id"],
           "onDelete": "no action",
@@ -442,6 +446,7 @@
           "name": "venture_members_user_id_users_id_fk",
           "tableFrom": "venture_members",
           "tableTo": "users",
+          "schemaTo": "impenetrable_connect",
           "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
           "onDelete": "no action",
@@ -454,9 +459,9 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.product_categories": {
+    "impenetrable_connect.product_categories": {
       "name": "product_categories",
-      "schema": "",
+      "schema": "impenetrable_connect",
       "columns": {
         "zzz_id": {
           "name": "zzz_id",
@@ -516,6 +521,7 @@
           "name": "product_categories_zzz_project_id_projects_zzz_id_fk",
           "tableFrom": "product_categories",
           "tableTo": "projects",
+          "schemaTo": "impenetrable_connect",
           "columnsFrom": ["zzz_project_id"],
           "columnsTo": ["zzz_id"],
           "onDelete": "no action",
@@ -528,9 +534,9 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.products": {
+    "impenetrable_connect.products": {
       "name": "products",
-      "schema": "",
+      "schema": "impenetrable_connect",
       "columns": {
         "zzz_id": {
           "name": "zzz_id",
@@ -614,6 +620,7 @@
           "name": "products_zzz_product_category_id_product_categories_zzz_id_fk",
           "tableFrom": "products",
           "tableTo": "product_categories",
+          "schemaTo": "impenetrable_connect",
           "columnsFrom": ["zzz_product_category_id"],
           "columnsTo": ["zzz_id"],
           "onDelete": "no action",
@@ -628,9 +635,9 @@
     }
   },
   "enums": {
-    "public.user_role": {
+    "impenetrable_connect.user_role": {
       "name": "user_role",
-      "schema": "public",
+      "schema": "impenetrable_connect",
       "values": ["ADMIN", "ENTREPRENEUR", "TOURIST"]
     }
   },

--- a/apps/backend/src/db/migrations/meta/_journal.json
+++ b/apps/backend/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1779409062658,
-      "tag": "0000_initial_schema",
+      "when": 1779579550800,
+      "tag": "0000_initial-schema",
       "breakpoints": true
     }
   ]

--- a/apps/backend/src/db/pre-push.ts
+++ b/apps/backend/src/db/pre-push.ts
@@ -1,0 +1,30 @@
+import postgres from "postgres";
+import { getAppConfig } from "../config/env";
+import { SCHEMA_NAME } from "./schema/base";
+import { logger } from "../services/logger.service";
+
+/**
+ * Pre-push script to ensure the custom database schema exists
+ * before drizzle-kit push attempts to introspect it.
+ */
+async function prePush() {
+  const config = getAppConfig();
+  const url = config.directUrl || config.databaseUrl;
+
+  if (!url) {
+    throw new Error("Neither DATABASE_URL nor DIRECT_URL is defined in AppConfig");
+  }
+
+  const client = postgres(url, { max: 1 });
+  try {
+    logger.info(`Checking if database schema "${SCHEMA_NAME}" exists...`);
+    await client.unsafe(`CREATE SCHEMA IF NOT EXISTS ${SCHEMA_NAME};`);
+  } catch (error) {
+    logger.error(`Failed to create schema "${SCHEMA_NAME}":`, error);
+    process.exit(1);
+  } finally {
+    await client.end();
+  }
+}
+
+prePush();

--- a/apps/backend/src/db/schema/base.ts
+++ b/apps/backend/src/db/schema/base.ts
@@ -1,4 +1,12 @@
-import { timestamp } from "drizzle-orm/pg-core";
+import { timestamp, pgSchema } from "drizzle-orm/pg-core";
+
+export const SCHEMA_NAME = "impenetrable_connect";
+
+/**
+ * Custom schema for impenetrable-connect database objects.
+ * Uses underscore to avoid mandatory SQL quoting.
+ */
+export const impenetrableSchema = pgSchema(SCHEMA_NAME);
 
 /**
  * Standard Audit Pattern: Common audit columns for all tables.

--- a/apps/backend/src/db/schema/index.ts
+++ b/apps/backend/src/db/schema/index.ts
@@ -5,3 +5,4 @@ export * from "./refresh-tokens";
 export * from "./venture-members";
 export * from "./product-categories";
 export * from "./products";
+export * from "./base";

--- a/apps/backend/src/db/schema/product-categories.ts
+++ b/apps/backend/src/db/schema/product-categories.ts
@@ -1,8 +1,8 @@
-import { pgTable, serial, integer, boolean, jsonb } from "drizzle-orm/pg-core";
-import { auditColumns } from "./base";
+import { serial, integer, boolean, jsonb } from "drizzle-orm/pg-core";
+import { auditColumns, impenetrableSchema } from "./base";
 import { projects } from "./projects";
 
-export const productCategories = pgTable("product_categories", {
+export const productCategories = impenetrableSchema.table("product_categories", {
   zzz_id: serial("zzz_id").primaryKey(),
   zzz_project_id: integer("zzz_project_id")
     .references(() => projects.zzz_id)

--- a/apps/backend/src/db/schema/products.ts
+++ b/apps/backend/src/db/schema/products.ts
@@ -1,8 +1,8 @@
-import { pgTable, serial, integer, boolean, jsonb, varchar, numeric } from "drizzle-orm/pg-core";
-import { auditColumns } from "./base";
+import { serial, integer, boolean, jsonb, varchar, numeric } from "drizzle-orm/pg-core";
+import { auditColumns, impenetrableSchema } from "./base";
 import { productCategories } from "./product-categories";
 
-export const products = pgTable("products", {
+export const products = impenetrableSchema.table("products", {
   zzz_id: serial("zzz_id").primaryKey(),
   zzz_product_category_id: integer("zzz_product_category_id")
     .references(() => productCategories.zzz_id)

--- a/apps/backend/src/db/schema/projects.ts
+++ b/apps/backend/src/db/schema/projects.ts
@@ -1,7 +1,7 @@
-import { pgTable, serial, varchar, integer, boolean, jsonb } from "drizzle-orm/pg-core";
-import { auditColumns } from "./base";
+import { serial, varchar, integer, boolean, jsonb } from "drizzle-orm/pg-core";
+import { auditColumns, impenetrableSchema } from "./base";
 
-export const projects = pgTable("projects", {
+export const projects = impenetrableSchema.table("projects", {
   zzz_id: serial("zzz_id").primaryKey(),
   zzz_name: varchar("zzz_name", { length: 100 }).notNull(),
   zzz_default_language: varchar("zzz_default_language", { length: 10 }).notNull().default("es"),

--- a/apps/backend/src/db/schema/refresh-tokens.ts
+++ b/apps/backend/src/db/schema/refresh-tokens.ts
@@ -1,8 +1,8 @@
-import { pgTable, uuid, text, timestamp } from "drizzle-orm/pg-core";
-import { auditColumns } from "./base";
+import { uuid, text, timestamp } from "drizzle-orm/pg-core";
+import { auditColumns, impenetrableSchema } from "./base";
 import { users } from "./users";
 
-export const refreshTokens = pgTable("refresh_tokens", {
+export const refreshTokens = impenetrableSchema.table("refresh_tokens", {
   id: uuid("id").primaryKey().defaultRandom(),
   userId: uuid("user_id")
     .notNull()

--- a/apps/backend/src/db/schema/users.ts
+++ b/apps/backend/src/db/schema/users.ts
@@ -1,9 +1,13 @@
-import { pgTable, uuid, varchar, timestamp, pgEnum, integer, boolean } from "drizzle-orm/pg-core";
-import { auditColumns } from "./base";
+import { uuid, varchar, timestamp, integer, boolean } from "drizzle-orm/pg-core";
+import { auditColumns, impenetrableSchema } from "./base";
 
-export const userRoleEnum = pgEnum("user_role", ["ADMIN", "ENTREPRENEUR", "TOURIST"]);
+export const userRoleEnum = impenetrableSchema.enum("user_role", [
+  "ADMIN",
+  "ENTREPRENEUR",
+  "TOURIST",
+]);
 
-export const users = pgTable("users", {
+export const users = impenetrableSchema.table("users", {
   id: uuid("id").primaryKey().defaultRandom(),
   email: varchar("email", { length: 255 }).unique(), // Nullable for tourists
   alias: varchar("alias", { length: 50 }).unique(), // For tourists

--- a/apps/backend/src/db/schema/venture-members.ts
+++ b/apps/backend/src/db/schema/venture-members.ts
@@ -1,9 +1,9 @@
-import { pgTable, serial, varchar, uuid, integer } from "drizzle-orm/pg-core";
-import { auditColumns } from "./base";
+import { serial, varchar, uuid, integer } from "drizzle-orm/pg-core";
+import { auditColumns, impenetrableSchema } from "./base";
 import { ventures } from "./ventures";
 import { users } from "./users";
 
-export const ventureMembers = pgTable("venture_members", {
+export const ventureMembers = impenetrableSchema.table("venture_members", {
   id: serial("id").primaryKey(),
   ventureId: integer("venture_id")
     .notNull()

--- a/apps/backend/src/db/schema/ventures.ts
+++ b/apps/backend/src/db/schema/ventures.ts
@@ -1,9 +1,9 @@
-import { pgTable, serial, varchar, uuid, boolean, integer } from "drizzle-orm/pg-core";
-import { auditColumns } from "./base";
+import { serial, varchar, uuid, boolean, integer } from "drizzle-orm/pg-core";
+import { auditColumns, impenetrableSchema } from "./base";
 import { users } from "./users";
 import { projects } from "./projects";
 
-export const ventures = pgTable("ventures", {
+export const ventures = impenetrableSchema.table("ventures", {
   id: serial("id").primaryKey(),
   name: varchar("name", { length: 255 }).notNull(),
   ownerId: uuid("owner_id")

--- a/apps/backend/src/db/seed.ts
+++ b/apps/backend/src/db/seed.ts
@@ -1,6 +1,6 @@
 import { sql, eq } from "drizzle-orm";
 import { createDb, type Db } from "./index";
-import { projects, users, ventures, productCategories, products } from "./schema";
+import { projects, users, ventures, productCategories, products, SCHEMA_NAME } from "./schema";
 import {
   MOCK_PROJECTS,
   MOCK_USERS,
@@ -16,10 +16,11 @@ import { getAppConfig } from "../config/env";
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Resets the sequence for a table to the current max id. */
+/** Resets the sequence for a table to the current max id in custom schema. */
 async function resetSequence(db: Db, table: string, pkColumn: string) {
+  const seqName = `"${SCHEMA_NAME}"."${table}_${pkColumn}_seq"`;
   await db.execute(
-    sql`SELECT setval(${`${table}_${pkColumn}_seq`}, (SELECT MAX(${sql.identifier(pkColumn)}) FROM ${sql.identifier(table)}))`,
+    sql`SELECT setval(${seqName}, (SELECT MAX(${sql.identifier(pkColumn)}) FROM ${sql.identifier(SCHEMA_NAME)}.${sql.identifier(table)}))`,
   );
 }
 

--- a/openspec/explorations/postgres-custom-schema-explore.md
+++ b/openspec/explorations/postgres-custom-schema-explore.md
@@ -1,0 +1,52 @@
+# Exploration: Postgres Custom Schema
+
+## Current State
+
+Currently, all database tables and custom types (enums) are defined in the default `public` schema. When Drizzle generates migrations:
+
+- Enums are explicitly generated with `"public"."user_role"`.
+- Tables are generated as `"users"`, `"projects"`, etc., defaulting to whatever is the active search path (usually `public`).
+
+To isolate the application's tables and custom types from potential system tables or other applications sharing the same database (especially on cloud environments like Neon), we want to group everything under a dedicated, explicit PostgreSQL schema called `impenetrable`.
+
+## Affected Areas
+
+| File                                               | Impact                                                        |
+| -------------------------------------------------- | ------------------------------------------------------------- |
+| `apps/backend/src/db/schema/projects.ts`           | Define table under `impenetrableSchema`                       |
+| `apps/backend/src/db/schema/users.ts`              | Define enum and table under `impenetrableSchema`              |
+| `apps/backend/src/db/schema/ventures.ts`           | Define table under `impenetrableSchema`                       |
+| `apps/backend/src/db/schema/refresh-tokens.ts`     | Define table under `impenetrableSchema`                       |
+| `apps/backend/src/db/schema/venture-members.ts`    | Define table under `impenetrableSchema`                       |
+| `apps/backend/src/db/schema/product-categories.ts` | Define table under `impenetrableSchema`                       |
+| `apps/backend/src/db/schema/products.ts`           | Define table under `impenetrableSchema`                       |
+| `apps/backend/src/db/db-setup-advanced.ts`         | Update RLS and triggers to target tables in the custom schema |
+
+## Approaches
+
+### 1. Schema Name: `impenetrable`
+
+- **Pros**: Direct, simple, matches the domain.
+- **Cons**: None.
+- **Implementation**: Create a schema object `impenetrableSchema = pgSchema("impenetrable")` and define all objects on it.
+
+### 2. Schema Name: `impenetrable_connect`
+
+- **Pros**: Matches the full monorepo name.
+- **Cons**: Slightly longer, doesn't add much value over `impenetrable`.
+
+## Recommendation
+
+Use **Approach 1 (schema name `impenetrable`)**. It keeps names short and clean while fully satisfying database isolation requirements.
+
+## Risks & Gotchas
+
+1. **Triggers and Functions**:
+   In `db-setup-advanced.ts`, trigger setup must qualify the target tables with the new schema (e.g. `ALTER TABLE impenetrable.users ENABLE ROW LEVEL SECURITY`). The function `update_updated_at_column` should also be created inside the `impenetrable` schema or the search path must be correctly configured.
+2. **Migrations**:
+   Changing schemas is a destructive schema modification in the eyes of Drizzle-Kit because it looks like dropping tables in `public` and creating them in `impenetrable`.
+   Since we are in a development phase and the Neon DB is a development sandbox, a clean migration reset (`make db-reset` or resetting the Neon branch and generating a clean `0000` migration) is the safest approach to avoid complex SQL state mismatches.
+
+## Ready for Proposal
+
+**Yes** — We can proceed to `sdd-propose` directly.

--- a/openspec/proposals/postgres-custom-schema-proposal.md
+++ b/openspec/proposals/postgres-custom-schema-proposal.md
@@ -1,0 +1,99 @@
+# Proposal: Migrate to Custom Postgres Schema ("impenetrable-connect")
+
+## 1. Change Summary
+
+**What**: Migrate all database objects (tables and the custom `user_role` enum type) from the default `public` schema to a dedicated PostgreSQL schema called `"impenetrable-connect"`.
+
+**Why**: To isolate the application's tables and types from potential system tables or other apps sharing the same database. Using the exact project name `"impenetrable-connect"` provides a clear domain boundary.
+
+---
+
+## 2. Scope
+
+### Files to Modify
+
+| File                                               | Impact                                                                                    |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `apps/backend/src/db/schema/projects.ts`           | Change `pgTable` to `impenetrableSchema.table`                                            |
+| `apps/backend/src/db/schema/users.ts`              | Change `pgEnum` to `impenetrableSchema.enum` and `pgTable` to `impenetrableSchema.table`  |
+| `apps/backend/src/db/schema/ventures.ts`           | Change `pgTable` to `impenetrableSchema.table`                                            |
+| `apps/backend/src/db/schema/refresh-tokens.ts`     | Change `pgTable` to `impenetrableSchema.table`                                            |
+| `apps/backend/src/db/schema/venture-members.ts`    | Change `pgTable` to `impenetrableSchema.table`                                            |
+| `apps/backend/src/db/schema/product-categories.ts` | Change `pgTable` to `impenetrableSchema.table`                                            |
+| `apps/backend/src/db/schema/products.ts`           | Change `pgTable` to `impenetrableSchema.table`                                            |
+| `apps/backend/src/db/db-setup-advanced.ts`         | Qualify target tables in RLS and triggers with the `"impenetrable-connect"` schema prefix |
+
+### Migration Strategy
+
+We will recreate the initial migration (`0000_initial_schema.sql`) to cleanly target the `"impenetrable-connect"` schema:
+
+1. Delete local migration files (`0000_initial_schema.sql` and `meta/*`).
+2. Generate a clean initial migration using `make db-generate ENV_FILE=.env.neon NAME=initial-schema`.
+3. Clear/reset the target database (Neon and local).
+4. Run migrations and seed.
+
+---
+
+## 3. Implementation Plan
+
+### 3.1 Schema Definition Updates
+
+In `apps/backend/src/db/schema/base.ts`, we will define the schema:
+
+```typescript
+import { pgSchema } from "drizzle-orm/pg-core";
+export const impenetrableSchema = pgSchema("impenetrable-connect");
+```
+
+And replace:
+
+- `pgTable("name", ...)` with `impenetrableSchema.table("name", ...)`
+- `pgEnum("name", ...)` with `impenetrableSchema.enum("name", ...)`
+
+### 3.2 Advanced DB Setup (`db-setup-advanced.ts`)
+
+Update RLS and Triggers setup to qualify the tables (note the double quotes for the hyphenated schema name):
+
+```typescript
+const tables = ["users", "projects", "ventures", "refresh_tokens"];
+for (const table of tables) {
+  // Alter table under the 'impenetrable-connect' schema (quoted)
+  await db.execute(
+    sql.raw(`ALTER TABLE "impenetrable-connect".${table} ENABLE ROW LEVEL SECURITY;`),
+  );
+  await db.execute(
+    sql.raw(`DROP TRIGGER IF EXISTS trg_update_updated_at ON "impenetrable-connect".${table};`),
+  );
+  await db.execute(
+    sql.raw(`
+    CREATE TRIGGER trg_update_updated_at
+    BEFORE UPDATE ON "impenetrable-connect".${table}
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+  `),
+  );
+}
+```
+
+---
+
+## 4. Risks & Mitigation
+
+| Risk                                   | Severity | Mitigation                                                                                                                                                                                               |
+| -------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Hyphen SQL Syntax Error                | High     | The hyphen `-` is a subtraction operator in SQL. We must ensure the schema name is always properly quoted as `"impenetrable-connect"` in raw queries. Drizzle handles this automatically in compilation. |
+| Destructive migration conflict on Neon | High     | Reset the database or drop existing tables in `public` before applying the new migrations.                                                                                                               |
+| Broken application queries             | Low      | Drizzle automatically handles the schema prefixing (compiles queries to `"impenetrable-connect"."table_name"`), so no changes are needed in query logic.                                                 |
+| Test failures                          | Low      | Tests using the mock DB factory or local Postgres will run migrations cleanly in their test runner.                                                                                                      |
+
+---
+
+## 5. Next Steps
+
+1. **Obtain user approval** on this proposal.
+2. **Interactive SDD steps**:
+   - Create OpenSpec/Design (`openspec/specs/` and `openspec/designs/`).
+   - Create task checklist (`openspec/tasks/`).
+   - Run implementation (Apply phase).
+   - Run verification and tests (Verify phase).
+   - Archive changes.


### PR DESCRIPTION
# Pull Request Template

## Linked Issue

Closes #209

## Summary

- Migrated all database tables and custom enum types from the `public` schema to a dedicated custom schema `"impenetrable_connect"`.
- Centralized the schema name definition under the `SCHEMA_NAME` constant in `base.ts` to prevent duplication across schemas, migrations, seeds, and advanced triggers.

## Changes

| File | Change |
| ---- | ------ |
| `apps/backend/src/db/schema/base.ts` | Export centralized `SCHEMA_NAME` constant and declare `impenetrableSchema` |
| `apps/backend/src/db/schema/index.ts` | Export base schema variables |
| `apps/backend/src/db/schema/*.ts` | Update database schemas to define resources under `impenetrableSchema` |
| `apps/backend/src/db/migrate.ts` | Create custom schema pre-migration using `SCHEMA_NAME` |
| `apps/backend/src/db/db-setup-advanced.ts` | Refactor RLS and triggers to namespace under `SCHEMA_NAME` |
| `apps/backend/src/db/seed.ts` | Qualify sequence resetting functions and lookups using `SCHEMA_NAME` |
| `apps/backend/src/db/migrations/*` | Recreate initial migration targeting custom schema |

## Test Summary

✅ PASS: 91 total tests, make check successful

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran `make check` and tests pass
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
